### PR TITLE
Integrate Balanço Energético leads pages with BFF mock

### DIFF
--- a/src/hooks/useSimulationClientes.ts
+++ b/src/hooks/useSimulationClientes.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { Cliente } from '../types';
+import { fetchLeadSimulationClientes } from '../services/leadSimulationApi';
+
+export function useSimulationClientes() {
+  const [clientes, setClientes] = useState<Cliente[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isUsingFallback, setIsUsingFallback] = useState(false);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    let mounted = true;
+
+    async function load() {
+      setLoading(true);
+      const result = await fetchLeadSimulationClientes(abortController.signal);
+      if (!mounted) return;
+
+      setClientes(result.clientes);
+      setIsUsingFallback(result.fromCache);
+      setError(result.error ?? null);
+      setLoading(false);
+    }
+
+    load();
+
+    return () => {
+      mounted = false;
+      abortController.abort();
+    };
+  }, []);
+
+  return { clientes, loading, error, isUsingFallback };
+}

--- a/src/pages/SimulationClientPage.tsx
+++ b/src/pages/SimulationClientPage.tsx
@@ -1,14 +1,50 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import ModalEnergyDetails from '../components/ModalEnergyDetails';
 import { Link, useParams } from 'react-router-dom';
-import { mockClientes } from '../data/mockData';
+import { useSimulationClientes } from '../hooks/useSimulationClientes';
 
 export default function SimulationClientPage() {
   const { clientId } = useParams();
-  const cliente = mockClientes.find((c) => c.id.toString() === clientId);
+  const { clientes, loading, error, isUsingFallback } = useSimulationClientes();
+
+  const cliente = useMemo(
+    () => clientes.find((c) => c.id.toString() === (clientId ?? '')),
+    [clientes, clientId]
+  );
+
+  const backLinkClass =
+    'inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-[#2b3238] rounded-lg px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-[#232932] transition-colors';
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Link
+          to="/leads/simulation"
+          className={backLinkClass}
+        >
+          ← Voltar
+        </Link>
+        <div className="rounded-lg border border-gray-200 dark:border-[#2b3238] bg-white dark:bg-[#1a1f24] p-6 text-sm text-gray-600 dark:text-gray-300">
+          Carregando dados do cliente...
+        </div>
+      </div>
+    );
+  }
 
   if (!cliente) {
-    return <div>Cliente não encontrado</div>;
+    return (
+      <div className="space-y-4">
+        <Link
+          to="/leads/simulation"
+          className={backLinkClass}
+        >
+          ← Voltar
+        </Link>
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          Cliente não encontrado.
+        </div>
+      </div>
+    );
   }
 
   // Helpers e simulação de custos (placeholders visuais)
@@ -83,11 +119,18 @@ export default function SimulationClientPage() {
 
   return (
     <div className="space-y-6">
+      {isUsingFallback && (
+        <div className="rounded-lg border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-700">
+          Não foi possível conectar ao BFF mock. Exibindo dados de demonstração.
+          {error ? ` (${error})` : ''}
+        </div>
+      )}
+
       <div className="flex items-start justify-between">
         <div>
           <Link
             to="/leads/simulation"
-            className="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-[#2b3238] rounded-lg px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-[#232932] transition-colors"
+            className={backLinkClass}
           >
             ← Voltar
           </Link>

--- a/src/pages/SimulationClientsPage.tsx
+++ b/src/pages/SimulationClientsPage.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import ListRow from '../components/ListRow';
-import { mockClientes } from '../data/mockData';
+import EmptyState from '../components/EmptyState';
+import { useSimulationClientes } from '../hooks/useSimulationClientes';
 
 export default function SimulationClientsPage() {
+  const { clientes, loading, error, isUsingFallback } = useSimulationClientes();
+
   return (
     <div className="space-y-4">
       <div>
@@ -13,22 +15,35 @@ export default function SimulationClientsPage() {
         </p>
       </div>
 
+      {isUsingFallback && (
+        <div className="rounded-lg border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-700">
+          Não foi possível conectar ao BFF mock. Exibindo dados de demonstração.
+          {error ? ` (${error})` : ''}
+        </div>
+      )}
+
       <div className="bg-white dark:bg-[#1a1f24] rounded-xl border border-gray-200 dark:border-[#2b3238] shadow-sm">
-        <ul className="divide-y divide-gray-100 dark:divide-[#2b3238]">
-          {mockClientes.map((cliente) => (
-            <ListRow
-              key={cliente.id}
-              to={`/leads/simulation/${cliente.id}`}
-              title={cliente.nome}
-              badgeLabel={`Bandeira: ${cliente.bandeira}`}
-              detail={`Imposto: ${cliente.imposto} • Consumo: ${cliente.consumo} kWh • Geração: ${cliente.geracao} kWh`}
-              rightPill={{
-                label: `${cliente.balanco >= 0 ? 'Saldo +' : 'Saldo -'} ${Math.abs(cliente.balanco)} kWh`,
-                color: cliente.balanco >= 0 ? 'green' : 'red',
-              }}
-            />
-          ))}
-        </ul>
+        {loading ? (
+          <div className="p-6 text-sm text-gray-500 dark:text-gray-300">Carregando clientes...</div>
+        ) : clientes.length === 0 ? (
+          <EmptyState message="Nenhum cliente retornado pelo BFF." />
+        ) : (
+          <ul className="divide-y divide-gray-100 dark:divide-[#2b3238]">
+            {clientes.map((cliente) => (
+              <ListRow
+                key={cliente.id}
+                to={`/leads/simulation/${cliente.id}`}
+                title={cliente.nome}
+                badgeLabel={`Bandeira: ${cliente.bandeira}`}
+                detail={`Imposto: ${cliente.imposto} • Consumo: ${cliente.consumo} kWh • Geração: ${cliente.geracao} kWh`}
+                rightPill={{
+                  label: `${cliente.balanco >= 0 ? 'Saldo +' : 'Saldo -'} ${Math.abs(cliente.balanco)} kWh`,
+                  color: cliente.balanco >= 0 ? 'green' : 'red',
+                }}
+              />
+            ))}
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/src/services/leadSimulationApi.ts
+++ b/src/services/leadSimulationApi.ts
@@ -1,7 +1,20 @@
 import { Cliente } from '../types';
 import { mockClientes } from '../data/mockData';
 
+type FetchOptions = {
+  signal?: AbortSignal;
+};
+
+export type LeadSimulationResponse = {
+  clientes: Cliente[];
+  fromCache: boolean;
+  error?: string;
+};
+
 const DEFAULT_BFF_URL = 'https://n8n.ynovamarketplace.com/webhook-test/mockScde';
+
+let lastResult: LeadSimulationResponse | null = null;
+let lastRemoteClientes: Cliente[] | null = null;
 
 function parseNumber(value: unknown): number {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -31,17 +44,22 @@ function normalizeCliente(raw: any, index: number): Cliente {
   const consumo =
     parseNumber(raw?.consumo) ||
     parseNumber(raw?.consumo_kwh) ||
-    parseNumber(raw?.consumoKwh);
+    parseNumber(raw?.consumoKwh) ||
+    parseNumber(raw?.kwh_consumo) ||
+    parseNumber(raw?.energiaAtual);
   const geracao =
     parseNumber(raw?.geracao) ||
     parseNumber(raw?.geracao_kwh) ||
-    parseNumber(raw?.geracaoKwh);
+    parseNumber(raw?.geracaoKwh) ||
+    parseNumber(raw?.kwh_geracao) ||
+    parseNumber(raw?.energiaGerada);
   const balancoRaw =
     parseNumber(raw?.balanco) ||
     parseNumber(raw?.saldoEnergetico) ||
-    parseNumber(raw?.saldo);
+    parseNumber(raw?.saldo) ||
+    parseNumber(raw?.balancoEnergetico);
 
-  const idValue = raw?.id ?? raw?.clienteId ?? raw?.leadId ?? index + 1;
+  const idValue = raw?.id ?? raw?.clienteId ?? raw?.leadId ?? raw?.codigo ?? index + 1;
   const id = Number.parseInt(String(idValue), 10);
 
   const nome =
@@ -49,9 +67,15 @@ function normalizeCliente(raw: any, index: number): Cliente {
     raw?.name ??
     raw?.razaoSocial ??
     raw?.cliente ??
+    raw?.empresa ??
     `Cliente ${index + 1}`;
 
-  const bandeira = raw?.bandeira ?? raw?.flag ?? raw?.tarifaBandeira ?? 'Sem bandeira';
+  const bandeira =
+    raw?.bandeira ??
+    raw?.flag ??
+    raw?.tarifaBandeira ??
+    raw?.categoria ??
+    'Sem bandeira';
 
   const impostoValue =
     raw?.imposto ??
@@ -60,6 +84,7 @@ function normalizeCliente(raw: any, index: number): Cliente {
     raw?.aliquotaExtra ??
     raw?.taxa ??
     raw?.percentualImposto ??
+    raw?.impostoExtra ??
     '0%';
 
   const imposto = ensurePercent(impostoValue);
@@ -77,44 +102,230 @@ function normalizeCliente(raw: any, index: number): Cliente {
   };
 }
 
-function extractClientes(payload: any): any[] {
-  if (!payload) return [];
-  if (Array.isArray(payload)) return payload;
-  if (Array.isArray(payload?.clientes)) return payload.clientes;
-  if (Array.isArray(payload?.data?.clientes)) return payload.data.clientes;
-  if (Array.isArray(payload?.data?.simulation?.clientes)) return payload.data.simulation.clientes;
-  if (Array.isArray(payload?.simulation?.clientes)) return payload.simulation.clientes;
-  if (Array.isArray(payload?.result?.clientes)) return payload.result.clientes;
-  return [];
+function isClienteLike(value: any): boolean {
+  if (!value || typeof value !== 'object') return false;
+  const keys = Object.keys(value).map((key) => key.toLowerCase());
+  const hasNome = keys.some((key) =>
+    ['nome', 'name', 'cliente', 'razaosocial', 'empresa', 'fantasia'].includes(key)
+  );
+  const hasConsumo = keys.some((key) =>
+    ['consumo', 'consumo_kwh', 'consumokwh', 'kwh_consumo', 'energiaatual'].includes(key)
+  );
+  const hasGeracaoOuSaldo = keys.some((key) =>
+    [
+      'geracao',
+      'geracao_kwh',
+      'geracaokwh',
+      'kwh_geracao',
+      'energiagerada',
+      'saldo',
+      'saldoenergetico',
+      'balanco',
+      'balancoenergetico',
+    ].includes(key)
+  );
+  return hasNome && (hasConsumo || hasGeracaoOuSaldo);
 }
 
-export type LeadSimulationResponse = {
-  clientes: Cliente[];
-  fromCache: boolean;
-  error?: string;
-};
+function tryParseJsonString(text: string): any {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
 
-export async function fetchLeadSimulationClientes(signal?: AbortSignal): Promise<LeadSimulationResponse> {
-  const endpoint = import.meta.env.VITE_BFF_LEADS_URL || DEFAULT_BFF_URL;
+  const tryParse = (value: string) => {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return null;
+    }
+  };
+
+  let parsed = tryParse(trimmed);
+  if (parsed !== null) return parsed;
+
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    const unescaped = tryParse(trimmed);
+    if (typeof unescaped === 'string') {
+      parsed = tryParse(unescaped);
+      if (parsed !== null) return parsed;
+      return unescaped;
+    }
+  }
+
+  return null;
+}
+
+function extractClientes(payload: any): any[] {
+  const visited = new Set<any>();
+
+  const search = (value: any): any[] => {
+    if (!value) return [];
+
+    if (Array.isArray(value)) {
+      const candidates = value.filter(isClienteLike);
+      if (candidates.length > 0) return candidates;
+      for (const item of value) {
+        const nested = search(item);
+        if (nested.length > 0) return nested;
+      }
+      return [];
+    }
+
+    if (typeof value === 'string') {
+      const parsed = tryParseJsonString(value);
+      if (parsed !== null) {
+        return search(parsed);
+      }
+      return [];
+    }
+
+    if (typeof value === 'object') {
+      if (visited.has(value)) return [];
+      visited.add(value);
+
+      const objectValues = Object.values(value);
+      const directClientes = objectValues.filter(isClienteLike);
+      if (directClientes.length > 0) return directClientes as any[];
+
+      const preferredKeys = [
+        'clientes',
+        'lista',
+        'listaclientes',
+        'dadosclientes',
+        'clientesenergia',
+        'leadclientes',
+        'items',
+        'rows',
+        'entries',
+        'result',
+        'data',
+        'payload',
+        'body',
+        'response',
+        'simulation',
+        'leadsimulation',
+        'balanco',
+      ];
+
+      for (const [key, nestedValue] of Object.entries(value)) {
+        const normalizedKey = key.toLowerCase();
+        if (preferredKeys.includes(normalizedKey)) {
+          const nested = search(nestedValue);
+          if (nested.length > 0) return nested;
+        }
+      }
+
+      for (const nestedValue of objectValues) {
+        const nested = search(nestedValue);
+        if (nested.length > 0) return nested;
+      }
+    }
+
+    return [];
+  };
+
+  const result = search(payload);
+  return Array.isArray(result) ? result : [];
+}
+
+function buildErrorMessage(label: string, error: unknown): string {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return `${label}: requisição cancelada`;
+  }
+  if (error instanceof Error) {
+    return `${label}: ${error.message}`;
+  }
+  return `${label}: erro desconhecido`;
+}
+
+async function parseResponsePayload(response: Response): Promise<any> {
+  const text = await response.text();
+  if (!text.trim()) return null;
+
+  const parsedDirect = tryParseJsonString(text);
+  if (parsedDirect !== null) return parsedDirect;
 
   try {
-    const response = await fetch(endpoint, { signal });
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-    const json = await response.json();
-    const rawClientes = extractClientes(json);
-    if (!Array.isArray(rawClientes) || rawClientes.length === 0) {
-      throw new Error('Resposta sem clientes');
-    }
-    const clientes = rawClientes.map((item, index) => normalizeCliente(item, index));
-    return { clientes, fromCache: false };
-  } catch (error) {
-    console.error('Erro ao buscar mock do BFF', error);
-    return {
-      clientes: mockClientes,
-      fromCache: true,
-      error: error instanceof Error ? error.message : 'Erro desconhecido',
-    };
+    return JSON.parse(text);
+  } catch {
+    return text;
   }
+}
+
+export function getCachedLeadSimulationClientes(): LeadSimulationResponse | null {
+  return lastResult;
+}
+
+export async function fetchLeadSimulationClientes({ signal }: FetchOptions = {}): Promise<LeadSimulationResponse> {
+  const endpoint = import.meta.env.VITE_BFF_LEADS_URL || DEFAULT_BFF_URL;
+  const preferredMethod = import.meta.env.VITE_BFF_LEADS_METHOD?.toUpperCase();
+
+  const attempts: Array<{ label: string; init: RequestInit }> = [];
+
+  const getAttempt: RequestInit = {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+    cache: 'no-cache',
+  };
+
+  const postAttempt: RequestInit = {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: '{}',
+    cache: 'no-cache',
+  };
+
+  if (preferredMethod === 'POST') {
+    attempts.push({ label: 'POST', init: postAttempt });
+    attempts.push({ label: 'GET', init: getAttempt });
+  } else if (preferredMethod === 'GET') {
+    attempts.push({ label: 'GET', init: getAttempt });
+    attempts.push({ label: 'POST', init: postAttempt });
+  } else {
+    attempts.push({ label: 'GET', init: getAttempt }, { label: 'POST', init: postAttempt });
+  }
+
+  const attemptErrors: string[] = [];
+
+  for (const attempt of attempts) {
+    try {
+      const response = await fetch(endpoint, { ...attempt.init, signal });
+      if (!response.ok) {
+        attemptErrors.push(`${attempt.label}: HTTP ${response.status}`);
+        continue;
+      }
+
+      const payload = await parseResponsePayload(response);
+      const rawClientes = extractClientes(payload);
+      if (!Array.isArray(rawClientes) || rawClientes.length === 0) {
+        attemptErrors.push(`${attempt.label}: resposta sem clientes válidos`);
+        continue;
+      }
+
+      const clientes = rawClientes.map((item, index) => normalizeCliente(item, index));
+      const result: LeadSimulationResponse = { clientes, fromCache: false };
+      lastResult = result;
+      lastRemoteClientes = clientes;
+      return result;
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw error;
+      }
+      attemptErrors.push(buildErrorMessage(attempt.label, error));
+    }
+  }
+
+  const fallbackClientes = lastRemoteClientes ?? mockClientes;
+  const errorMessage = attemptErrors.length > 0 ? attemptErrors.join(' | ') : 'Não foi possível conectar ao mock BFF';
+  const fallbackResult: LeadSimulationResponse = {
+    clientes: fallbackClientes,
+    fromCache: true,
+    error: errorMessage,
+  };
+  lastResult = fallbackResult;
+  return fallbackResult;
 }

--- a/src/services/leadSimulationApi.ts
+++ b/src/services/leadSimulationApi.ts
@@ -1,0 +1,120 @@
+import { Cliente } from '../types';
+import { mockClientes } from '../data/mockData';
+
+const DEFAULT_BFF_URL = 'https://n8n.ynovamarketplace.com/webhook-test/mockScde';
+
+function parseNumber(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const cleaned = value
+      .replace(/[^0-9.,-]/g, '')
+      .replace(/,(?=\d{3}(?:\D|$))/g, '.')
+      .replace(/\.(?=\d{3}(?:\D|$))/g, '')
+      .replace(',', '.');
+    const parsed = Number.parseFloat(cleaned);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function ensurePercent(value: unknown): string {
+  if (typeof value === 'string') {
+    return value.includes('%') ? value : `${value}%`;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return `${value}%`;
+  }
+  return '0%';
+}
+
+function normalizeCliente(raw: any, index: number): Cliente {
+  const consumo =
+    parseNumber(raw?.consumo) ||
+    parseNumber(raw?.consumo_kwh) ||
+    parseNumber(raw?.consumoKwh);
+  const geracao =
+    parseNumber(raw?.geracao) ||
+    parseNumber(raw?.geracao_kwh) ||
+    parseNumber(raw?.geracaoKwh);
+  const balancoRaw =
+    parseNumber(raw?.balanco) ||
+    parseNumber(raw?.saldoEnergetico) ||
+    parseNumber(raw?.saldo);
+
+  const idValue = raw?.id ?? raw?.clienteId ?? raw?.leadId ?? index + 1;
+  const id = Number.parseInt(String(idValue), 10);
+
+  const nome =
+    raw?.nome ??
+    raw?.name ??
+    raw?.razaoSocial ??
+    raw?.cliente ??
+    `Cliente ${index + 1}`;
+
+  const bandeira = raw?.bandeira ?? raw?.flag ?? raw?.tarifaBandeira ?? 'Sem bandeira';
+
+  const impostoValue =
+    raw?.imposto ??
+    raw?.impostoPercentual ??
+    raw?.aliquota ??
+    raw?.aliquotaExtra ??
+    raw?.taxa ??
+    raw?.percentualImposto ??
+    '0%';
+
+  const imposto = ensurePercent(impostoValue);
+
+  const balanco = balancoRaw || geracao - consumo;
+
+  return {
+    id: Number.isFinite(id) ? id : index + 1,
+    nome,
+    bandeira,
+    imposto,
+    consumo,
+    geracao,
+    balanco,
+  };
+}
+
+function extractClientes(payload: any): any[] {
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload;
+  if (Array.isArray(payload?.clientes)) return payload.clientes;
+  if (Array.isArray(payload?.data?.clientes)) return payload.data.clientes;
+  if (Array.isArray(payload?.data?.simulation?.clientes)) return payload.data.simulation.clientes;
+  if (Array.isArray(payload?.simulation?.clientes)) return payload.simulation.clientes;
+  if (Array.isArray(payload?.result?.clientes)) return payload.result.clientes;
+  return [];
+}
+
+export type LeadSimulationResponse = {
+  clientes: Cliente[];
+  fromCache: boolean;
+  error?: string;
+};
+
+export async function fetchLeadSimulationClientes(signal?: AbortSignal): Promise<LeadSimulationResponse> {
+  const endpoint = import.meta.env.VITE_BFF_LEADS_URL || DEFAULT_BFF_URL;
+
+  try {
+    const response = await fetch(endpoint, { signal });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const json = await response.json();
+    const rawClientes = extractClientes(json);
+    if (!Array.isArray(rawClientes) || rawClientes.length === 0) {
+      throw new Error('Resposta sem clientes');
+    }
+    const clientes = rawClientes.map((item, index) => normalizeCliente(item, index));
+    return { clientes, fromCache: false };
+  } catch (error) {
+    console.error('Erro ao buscar mock do BFF', error);
+    return {
+      clientes: mockClientes,
+      fromCache: true,
+      error: error instanceof Error ? error.message : 'Erro desconhecido',
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add a service that normalizes the BFF webhook response and falls back to local mocks when offline
- create a reusable hook to load Balanço Energético clients from the mock BFF endpoint
- update the list and detail pages to use the hook, show loading feedback, and surface fallback warnings

## Testing
- npm test *(fails: vitest suite expects jest globals like `expect` to be configured)*

------
https://chatgpt.com/codex/tasks/task_e_68d54a101550832788721b1934d8075b