### PR TITLE
Integrate webhook-backed energy balance flows

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_WEBHOOK_URL=https://n8n.ynovamarketplace.com/webhook-test/mockScde

--- a/src/components/ListRow.tsx
+++ b/src/components/ListRow.tsx
@@ -5,6 +5,7 @@ type PillColor = 'green' | 'red' | 'gray' | 'orange' | 'blue';
 
 type Props = {
   to?: string;
+  state?: unknown;
   onClick?: () => void;
   title: string;
   badgeLabel?: string;
@@ -15,6 +16,7 @@ type Props = {
 
 export default function ListRow({
   to,
+  state,
   onClick,
   title,
   badgeLabel,
@@ -62,7 +64,7 @@ export default function ListRow({
   if (to) {
     return (
       <li className="p-0">
-        <Link to={to} className="block">
+        <Link to={to} state={state} className="block">
           {content}
         </Link>
       </li>

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -72,6 +72,7 @@ export const mockClientes: Cliente[] = [
     consumo: 1000,
     geracao: 1200,
     balanco: 200,
+    saldo: 'Saldo +200 kWh',
   },
   {
     id: 2,
@@ -81,5 +82,6 @@ export const mockClientes: Cliente[] = [
     consumo: 800,
     geracao: 600,
     balanco: -200,
+    saldo: 'Saldo -200 kWh',
   },
 ];

--- a/src/hooks/useClientes.ts
+++ b/src/hooks/useClientes.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { Cliente } from '../types';
+import { fetchClientes } from '../services/clientes';
+
+let cachedClientes: Cliente[] | null = null;
+
+export function clearClientesCache() {
+  cachedClientes = null;
+}
+
+export function useClientes(initialClientes: Cliente[] = []) {
+  const [clientes, setClientesState] = useState<Cliente[]>(() => {
+    if (cachedClientes && cachedClientes.length) {
+      return cachedClientes;
+    }
+    if (initialClientes.length) {
+      cachedClientes = initialClientes;
+      return initialClientes;
+    }
+    return [];
+  });
+  const [loading, setLoading] = useState<boolean>(() => !(cachedClientes && cachedClientes.length));
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(!(cachedClientes && cachedClientes.length));
+    setError(null);
+
+    fetchClientes(controller.signal)
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        cachedClientes = data;
+        setClientesState(data);
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err : new Error('Erro inesperado ao carregar clientes'));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  const setClientes = useCallback<Dispatch<SetStateAction<Cliente[]>>>(
+    (updater) => {
+      setClientesState((prev) => {
+        const next = typeof updater === 'function' ? (updater as (prev: Cliente[]) => Cliente[])(prev) : updater;
+        cachedClientes = next;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchClientes();
+      cachedClientes = data;
+      setClientesState(data);
+      return data;
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Erro inesperado ao recarregar clientes'));
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const result = useMemo(
+    () => ({ clientes, loading, error, setClientes, refetch }),
+    [clientes, loading, error, setClientes, refetch],
+  );
+
+  return result;
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -22,6 +22,36 @@ const segmentos = ['Industrial', 'Comercial', 'Serviços', 'Agro', 'Logística']
 const contatos = ['João Silva', 'Maria Santos', 'Pedro Oliveira', 'Ana Souza', 'Carlos Lima'];
 const fontes: Contrato['fonte'][] = ['Convencional', 'Incentivada'];
 
+const mockEnergyClients = [
+  {
+    id: 1,
+    nome: 'Cliente Energia A',
+    bandeira: 'Verde',
+    imposto: '12%',
+    consumo: '1.000 kWh',
+    geracao: '1.200 kWh',
+    saldo: 'Saldo +200 kWh',
+  },
+  {
+    id: 2,
+    nome: 'Cliente Energia B',
+    bandeira: 'Amarela',
+    imposto: '15%',
+    consumo: '800 kWh',
+    geracao: '600 kWh',
+    saldo: 'Saldo -200 kWh',
+  },
+  {
+    id: 3,
+    nome: 'Cliente Energia C',
+    bandeira: 'Vermelha',
+    imposto: '10%',
+    consumo: '950 kWh',
+    geracao: '900 kWh',
+    saldo: 'Saldo -50 kWh',
+  },
+];
+
 const allContratos: Contrato[] = Array.from({ length: 24 }).map((_, i) => {
   const mes = months[i % months.length];
   const fonte = fontes[i % fontes.length];
@@ -65,6 +95,10 @@ function gerarSerie24Meses(seedStr: string, base: number, amplitude: number) {
 }
 
 export const handlers = [
+  http.get('https://n8n.ynovamarketplace.com/webhook-test/mockScde', () =>
+    HttpResponse.json(mockEnergyClients),
+  ),
+  http.get('/api/webhook-test/mockScde', () => HttpResponse.json(mockEnergyClients)),
   // Listagem de contratos com paginação
   http.get('/api/contratos', ({ request }) => {
     const url = new URL(request.url);

--- a/src/pages/SimulationClientPage.tsx
+++ b/src/pages/SimulationClientPage.tsx
@@ -1,18 +1,31 @@
 import React, { useState } from 'react';
 import ModalEnergyDetails from '../components/ModalEnergyDetails';
-import { Link, useParams } from 'react-router-dom';
-import { mockClientes } from '../data/mockData';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { useClientes } from '../hooks/useClientes';
+import type { Cliente } from '../types';
 
 export default function SimulationClientPage() {
   const { clientId } = useParams();
-  const cliente = mockClientes.find((c) => c.id.toString() === clientId);
+  const location = useLocation();
+  const locationState = (location.state as { cliente?: Cliente } | undefined) ?? {};
+  const { cliente: clienteFromState } = locationState;
+  const { clientes, loading, error } = useClientes(clienteFromState ? [clienteFromState] : []);
+
+  const cliente = clienteFromState ?? clientes.find((c) => c.id.toString() === String(clientId));
 
   if (!cliente) {
+    if (loading) {
+      return <div>Carregando cliente...</div>;
+    }
+    if (error) {
+      return <div>Erro ao carregar cliente: {error.message}</div>;
+    }
     return <div>Cliente não encontrado</div>;
   }
 
   // Helpers e simulação de custos (placeholders visuais)
-  const parsePercent = (txt: string) => {
+  const parsePercent = (txt?: string) => {
+    if (!txt) return 0;
     const n = parseFloat(txt.replace('%', '').replace(',', '.'));
     return isNaN(n) ? 0 : n / 100;
   };
@@ -25,7 +38,7 @@ export default function SimulationClientPage() {
   const tarifaAtual = 0.62; // R$/kWh
   const tarifaCativo = 0.50; // R$/kWh (estimada)
 
-  const consumoLiquido = Math.max(cliente.consumo - cliente.geracao, 0);
+  const consumoLiquido = Math.max((cliente.consumo ?? 0) - (cliente.geracao ?? 0), 0);
 
   // Itens de linha (resumo + detalhes) para as duas tabelas
   type Item = { label: string; quantidade: number; tarifa: number };
@@ -107,6 +120,12 @@ export default function SimulationClientPage() {
           </button>
         </div>
       </div>
+
+      {error && !loading && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          Não foi possível atualizar os dados do cliente automaticamente: {error.message}
+        </div>
+      )}
 
       {/* KPIs */}
       <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">

--- a/src/pages/SimulationClientsPage.tsx
+++ b/src/pages/SimulationClientsPage.tsx
@@ -1,9 +1,24 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useMemo } from 'react';
 import ListRow from '../components/ListRow';
-import { mockClientes } from '../data/mockData';
+import { useClientes } from '../hooks/useClientes';
+import type { Cliente } from '../types';
+
+function buildSaldo(cliente: Cliente) {
+  const amount = Math.abs(cliente.balanco).toLocaleString('pt-BR', { maximumFractionDigits: 2 });
+  const prefix = cliente.balanco > 0 ? '+' : cliente.balanco < 0 ? '-' : '';
+  const label = cliente.saldo ?? `Saldo ${prefix}${amount} kWh`;
+  const color = cliente.balanco > 0 ? 'green' : cliente.balanco < 0 ? 'red' : 'gray';
+  return { label, color } as const;
+}
 
 export default function SimulationClientsPage() {
+  const { clientes, loading, error } = useClientes();
+
+  const items = useMemo(() => clientes.map((cliente) => ({
+      cliente,
+      saldo: buildSaldo(cliente),
+    })), [clientes]);
+
   return (
     <div className="space-y-4">
       <div>
@@ -14,21 +29,30 @@ export default function SimulationClientsPage() {
       </div>
 
       <div className="bg-white dark:bg-[#1a1f24] rounded-xl border border-gray-200 dark:border-[#2b3238] shadow-sm">
-        <ul className="divide-y divide-gray-100 dark:divide-[#2b3238]">
-          {mockClientes.map((cliente) => (
-            <ListRow
-              key={cliente.id}
-              to={`/leads/simulation/${cliente.id}`}
-              title={cliente.nome}
-              badgeLabel={`Bandeira: ${cliente.bandeira}`}
-              detail={`Imposto: ${cliente.imposto} • Consumo: ${cliente.consumo} kWh • Geração: ${cliente.geracao} kWh`}
-              rightPill={{
-                label: `${cliente.balanco >= 0 ? 'Saldo +' : 'Saldo -'} ${Math.abs(cliente.balanco)} kWh`,
-                color: cliente.balanco >= 0 ? 'green' : 'red',
-              }}
-            />
-          ))}
-        </ul>
+        {loading ? (
+          <div className="p-4 text-sm text-gray-600 dark:text-gray-300">Carregando clientes...</div>
+        ) : error ? (
+          <div className="p-4 text-sm text-red-600">Erro ao carregar clientes: {error.message}</div>
+        ) : items.length === 0 ? (
+          <div className="p-4 text-sm text-gray-600 dark:text-gray-300">Nenhum cliente disponível.</div>
+        ) : (
+          <ul className="divide-y divide-gray-100 dark:divide-[#2b3238]">
+            {items.map(({ cliente, saldo }) => (
+              <ListRow
+                key={cliente.id}
+                to={`/leads/simulation/${cliente.id}`}
+                state={{ cliente }}
+                title={cliente.nome}
+                badgeLabel={`Bandeira: ${cliente.bandeira}`}
+                detail={`Imposto: ${cliente.imposto} • Consumo: ${cliente.consumo.toLocaleString('pt-BR')} kWh • Geração: ${cliente.geracao.toLocaleString('pt-BR')} kWh`}
+                rightPill={{
+                  label: saldo.label,
+                  color: saldo.color,
+                }}
+              />
+            ))}
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/src/services/clientes.ts
+++ b/src/services/clientes.ts
@@ -1,0 +1,156 @@
+import type { Cliente } from '../types';
+
+const FALLBACK_WEBHOOK_PATH = '/api/webhook-test/mockScde';
+
+export type RawCliente = Record<string, unknown>;
+
+function parseNumberish(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    let cleaned = trimmed
+      .replace(/[^0-9,.-]+/g, '')
+      .replace(/(?!^)-/g, '');
+    if (!cleaned) {
+      return null;
+    }
+    const hasComma = cleaned.includes(',');
+    const hasDot = cleaned.includes('.');
+    const lastComma = cleaned.lastIndexOf(',');
+    const lastDot = cleaned.lastIndexOf('.');
+
+    if (hasComma && hasDot) {
+      if (lastComma > lastDot) {
+        cleaned = cleaned.replace(/\./g, '').replace(',', '.');
+      } else {
+        cleaned = cleaned.replace(/,/g, '');
+      }
+    } else if (hasComma) {
+      cleaned = cleaned.replace(',', '.');
+    } else if (hasDot) {
+      const decimals = cleaned.length - lastDot - 1;
+      const groups = cleaned.split('.');
+      const grouped = groups.length > 1 && groups.slice(1).every((chunk) => chunk.length === 3);
+      if (decimals === 3 && grouped) {
+        cleaned = cleaned.replace(/\./g, '');
+      }
+    }
+
+    cleaned = cleaned.replace(/,/g, '');
+
+    const parsed = Number.parseFloat(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function formatSaldoLabel(balance: number | null): string | undefined {
+  if (balance === null) return undefined;
+  const rounded = Math.round(balance * 100) / 100;
+  const absolute = Math.abs(rounded);
+  const prefix = rounded > 0 ? '+' : rounded < 0 ? '-' : '';
+  const formatted = absolute.toLocaleString('pt-BR', {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: absolute % 1 === 0 ? 0 : 2,
+  });
+  return `Saldo ${prefix}${formatted} kWh`;
+}
+
+function normalizeCliente(raw: RawCliente, index: number): Cliente | null {
+  const rawId = raw.id ?? raw.ID ?? raw.clienteId ?? raw.codigo ?? raw.slug ?? index + 1;
+  const idNumber = parseNumberish(rawId);
+  const id = Number.isFinite(idNumber) ? Number(idNumber) : index + 1;
+  const nome =
+    (typeof raw.nome === 'string' && raw.nome.trim()) ||
+    (typeof raw.name === 'string' && raw.name.trim()) ||
+    (typeof raw.cliente === 'string' && raw.cliente.trim()) ||
+    `Cliente ${index + 1}`;
+
+  const bandeira =
+    (typeof raw.bandeira === 'string' && raw.bandeira) ||
+    (typeof raw.flag === 'string' && raw.flag) ||
+    undefined;
+
+  const impostoValue = raw.imposto ?? raw.aliquota ?? raw.tax ?? raw.impostoPercentual;
+  const imposto =
+    typeof impostoValue === 'string'
+      ? impostoValue
+      : typeof impostoValue === 'number'
+      ? `${impostoValue}%`
+      : undefined;
+
+  const consumo = parseNumberish(raw.consumo ?? raw.consumo_kwh ?? raw.consumoKwh);
+  const geracao = parseNumberish(raw.geracao ?? raw.geracao_kwh ?? raw.geracaoKwh ?? raw.producao);
+  const balance =
+    parseNumberish(raw.balanco ?? raw.balance ?? raw.saldo ?? raw.saldo_kwh ?? raw.saldoKwh) ??
+    (consumo !== null && geracao !== null ? geracao - consumo : null);
+
+  const saldoString =
+    typeof raw.saldo === 'string' && raw.saldo.trim()
+      ? raw.saldo.trim()
+      : typeof raw.saldo_display === 'string'
+      ? raw.saldo_display.trim()
+      : undefined;
+
+  const balanco = Number.isFinite(balance) ? (balance as number) : 0;
+  const consumoKwh = Number.isFinite(consumo) ? (consumo as number) : 0;
+  const geracaoKwh = Number.isFinite(geracao) ? (geracao as number) : 0;
+
+  return {
+    id: Number.isFinite(id) ? Number(id) : index + 1,
+    nome,
+    bandeira: bandeira ?? '—',
+    imposto: imposto ?? '—',
+    consumo: consumoKwh,
+    geracao: geracaoKwh,
+    balanco: balanco,
+    saldo: saldoString ?? formatSaldoLabel(balance),
+  };
+}
+
+function extractClientes(payload: unknown): RawCliente[] {
+  if (Array.isArray(payload)) return payload as RawCliente[];
+  if (payload && typeof payload === 'object') {
+    const maybeArray = (payload as Record<string, unknown>).clientes;
+    if (Array.isArray(maybeArray)) return maybeArray as RawCliente[];
+  }
+  return [];
+}
+
+export async function fetchClientes(signal?: AbortSignal): Promise<Cliente[]> {
+  const envUrl = import.meta.env.VITE_WEBHOOK_URL;
+  const url = envUrl && envUrl.trim() ? envUrl.trim() : FALLBACK_WEBHOOK_PATH;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Erro ao carregar clientes (HTTP ${response.status})`);
+  }
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch (error) {
+    throw new Error('Resposta inválida do webhook de clientes');
+  }
+
+  const rawClientes = extractClientes(data);
+  if (!rawClientes.length) {
+    return [];
+  }
+
+  return rawClientes
+    .map((raw, index) => normalizeCliente(raw, index))
+    .filter((cliente): cliente is Cliente => Boolean(cliente));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,4 +38,5 @@ export type Cliente = {
   consumo: number; // kWh consumidos
   geracao: number; // kWh gerados
   balanco: number; // saldo energético (geracao - consumo)
+  saldo?: string; // representação formatada do saldo energético
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,14 @@ export default defineConfig({
       clientPort: 443,
       protocol: 'wss',
     },
+    proxy: {
+      '/api': {
+        target: 'https://n8n.ynovamarketplace.com',
+        changeOrigin: true,
+        secure: false,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- add a configurable webhook URL and dev proxy to ease local energy balance integrations
- create a typed webhook client and shared hook to load clientes with loading/error state and cache
- update energy balance listing/detail pages, list row navigation, and mocks to render dynamic webhook data

## Testing
- npm run build
- npm test *(fails: ReferenceError: expect is not defined in vitest setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d57b3e02a083278d3cbaff69e64df1