### PR TITLE
Add energy balance hook and page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import TrainingPage from './pages/TrainingPage';
 import SimulationClientsPage from './pages/SimulationClientsPage';
 import SimulationClientPage from './pages/SimulationClientPage';
 import OportunidadesPage from './pages/OportunidadesPage';
+import BalancoEnergeticoPage from './pages/BalancoEnergeticoPage';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import ContratosPage from './pages/contratos';
 import DetalheContratoPage from './pages/contratos/DetalheContrato';
@@ -50,6 +51,7 @@ function AppRoutes() {
             <Route path="dashboard" element={<DashboardPage />} />
             <Route path="oportunidades" element={<OportunidadesPage />} />
             <Route path="inteligencia" element={<InteligenciaPage />} />
+            <Route path="balanco-energetico" element={<BalancoEnergeticoPage />} />
 
             {/* Gestão: Contratos */}
             <Route path="contratos" element={<ContratosPage />} />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -14,6 +14,7 @@ import {
   GraduationCap,
   Handshake,
   Upload,
+  BarChart3,
 } from 'lucide-react';
 import CrownIcon from './icons/CrownIcon';
 import { mockUser } from '../data/mockData';
@@ -21,6 +22,7 @@ import { mockUser } from '../data/mockData';
 const navigation = [
   { to: '/dashboard', label: 'Dashboard', icon: Home },
   { to: '/contratos', label: 'Contratos', icon: PieChart },
+  { to: '/balanco-energetico', label: 'Balanço Energético', icon: BarChart3 },
   { to: '/leads', label: 'Leads', icon: FileText },
   { to: '/negociacoes', label: 'Negociações', icon: Handshake },
   { to: '/agenda', label: 'Agenda', icon: Calendar },

--- a/src/hooks/useBalancoEnergetico.ts
+++ b/src/hooks/useBalancoEnergetico.ts
@@ -24,7 +24,17 @@ export function useBalancoEnergetico() {
     queryFn: async () => {
       const res = await fetch('https://n8n.ynovamarketplace.com/webhook/mockScde');
       if (!res.ok) throw new Error('Erro ao carregar dados do balanço energético');
-      return res.json();
+      const payload = await res.json();
+
+      if (Array.isArray(payload)) {
+        return payload;
+      }
+
+      if (payload && typeof payload === 'object') {
+        return [payload as BalancoEnergetico];
+      }
+
+      return [];
     },
   });
 }

--- a/src/hooks/useBalancoEnergetico.ts
+++ b/src/hooks/useBalancoEnergetico.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface BalancoEnergetico {
+  cliente: string;
+  preco: number | null;
+  data_base: string | null;
+  reajustado: number | null;
+  fornecedor: string | null;
+  medidor: string | null;
+  consumo: number | null;
+  medicao: string | null;
+  proinfa: number | null;
+  contrato: number | null;
+  minimo: number | null;
+  maximo: number | null;
+  faturar: number | null;
+  cp: string | null;
+  encargos: string | null;
+}
+
+export function useBalancoEnergetico() {
+  return useQuery<BalancoEnergetico[]>({
+    queryKey: ['balancoEnergetico'],
+    queryFn: async () => {
+      const res = await fetch('https://n8n.ynovamarketplace.com/webhook/mockScde');
+      if (!res.ok) throw new Error('Erro ao carregar dados do balanço energético');
+      return res.json();
+    },
+  });
+}

--- a/src/pages/BalancoEnergeticoPage.tsx
+++ b/src/pages/BalancoEnergeticoPage.tsx
@@ -1,0 +1,36 @@
+import { useBalancoEnergetico } from '../hooks/useBalancoEnergetico';
+
+export default function BalancoEnergeticoPage() {
+  const { data, isLoading, error } = useBalancoEnergetico();
+
+  if (isLoading) return <p>Carregando...</p>;
+  if (error) return <p>Erro ao carregar os dados</p>;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Balanço Energético</h1>
+      <table className="w-full border border-gray-300">
+        <thead>
+          <tr className="bg-gray-200">
+            <th className="p-2">Cliente</th>
+            <th className="p-2">Fornecedor</th>
+            <th className="p-2">Consumo (MWh)</th>
+            <th className="p-2">Preço</th>
+            <th className="p-2">Reajustado</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.map((item, idx) => (
+            <tr key={idx} className="border-t">
+              <td className="p-2">{item.cliente}</td>
+              <td className="p-2">{item.fornecedor ?? '-'}</td>
+              <td className="p-2">{item.consumo ?? '-'}</td>
+              <td className="p-2">{item.preco ?? '-'}</td>
+              <td className="p-2">{item.reajustado ?? '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/BalancoEnergeticoPage.tsx
+++ b/src/pages/BalancoEnergeticoPage.tsx
@@ -4,33 +4,45 @@ export default function BalancoEnergeticoPage() {
   const { data, isLoading, error } = useBalancoEnergetico();
 
   if (isLoading) return <p>Carregando...</p>;
-  if (error) return <p>Erro ao carregar os dados</p>;
+  if (error)
+    return (
+      <p>
+        Erro ao carregar os dados{' '}
+        {error instanceof Error ? `(${error.message})` : null}
+      </p>
+    );
+
+  const rows = Array.isArray(data) ? data : [];
 
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Balanço Energético</h1>
-      <table className="w-full border border-gray-300">
-        <thead>
-          <tr className="bg-gray-200">
-            <th className="p-2">Cliente</th>
-            <th className="p-2">Fornecedor</th>
-            <th className="p-2">Consumo (MWh)</th>
-            <th className="p-2">Preço</th>
-            <th className="p-2">Reajustado</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data?.map((item, idx) => (
-            <tr key={idx} className="border-t">
-              <td className="p-2">{item.cliente}</td>
-              <td className="p-2">{item.fornecedor ?? '-'}</td>
-              <td className="p-2">{item.consumo ?? '-'}</td>
-              <td className="p-2">{item.preco ?? '-'}</td>
-              <td className="p-2">{item.reajustado ?? '-'}</td>
+      {rows.length ? (
+        <table className="w-full border border-gray-300">
+          <thead>
+            <tr className="bg-gray-200">
+              <th className="p-2">Cliente</th>
+              <th className="p-2">Fornecedor</th>
+              <th className="p-2">Consumo (MWh)</th>
+              <th className="p-2">Preço</th>
+              <th className="p-2">Reajustado</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {rows.map((item, idx) => (
+              <tr key={idx} className="border-t">
+                <td className="p-2">{item.cliente}</td>
+                <td className="p-2">{item.fornecedor ?? '-'}</td>
+                <td className="p-2">{item.consumo ?? '-'}</td>
+                <td className="p-2">{item.preco ?? '-'}</td>
+                <td className="p-2">{item.reajustado ?? '-'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>Sem dados disponíveis no momento.</p>
+      )}
     </div>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,5 +18,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: 'src/test/setup.ts',
+    globals: true,
   }
 })


### PR DESCRIPTION
## Summary
- add a dedicated React Query hook to retrieve the energy balance data from the n8n webhook
- create the Balanço Energético page that renders the fetched data in a table and wire it into the app routes
- expose the page in the main navigation and enable Vitest globals for existing tests

## Testing
- npm test -- --run *(fails: existing tests depend on ResizeObserver and focusable inputs under jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68d58218ee388327b8a03737cee896a5