### PR TITLE
Fetch energy balance data from backend

### DIFF
--- a/src/pages/SimulationClientsPage.tsx
+++ b/src/pages/SimulationClientsPage.tsx
@@ -15,6 +15,12 @@ export default function SimulationClientsPage() {
         </p>
       </div>
 
+      {error && !isUsingFallback && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          Erro ao carregar clientes: {error}
+        </div>
+      )}
+
       {isUsingFallback && (
         <div className="rounded-lg border border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-700">
           Não foi possível conectar ao BFF mock. Exibindo dados de demonstração.
@@ -24,7 +30,7 @@ export default function SimulationClientsPage() {
 
       <div className="bg-white dark:bg-[#1a1f24] rounded-xl border border-gray-200 dark:border-[#2b3238] shadow-sm">
         {loading ? (
-          <div className="p-6 text-sm text-gray-500 dark:text-gray-300">Carregando clientes...</div>
+          <div className="p-6 text-sm text-gray-500 dark:text-gray-300">Carregando…</div>
         ) : clientes.length === 0 ? (
           <EmptyState message="Nenhum cliente retornado pelo BFF." />
         ) : (
@@ -37,8 +43,8 @@ export default function SimulationClientsPage() {
                 badgeLabel={`Bandeira: ${cliente.bandeira}`}
                 detail={`Imposto: ${cliente.imposto} • Consumo: ${cliente.consumo} kWh • Geração: ${cliente.geracao} kWh`}
                 rightPill={{
-                  label: `${cliente.balanco >= 0 ? 'Saldo +' : 'Saldo -'} ${Math.abs(cliente.balanco)} kWh`,
-                  color: cliente.balanco >= 0 ? 'green' : 'red',
+                  label: `Saldo ${cliente.balanco >= 0 ? '+' : '-'}${Math.abs(cliente.balanco)} kWh`,
+                  color: 'green',
                 }}
               />
             ))}


### PR DESCRIPTION
## Summary
- update the energy balance service to consume the production webhook, parse nested fields from the new payload and detect single-object responses as clientes
- surface loading, error, and saldo styling adjustments on the leads simulation list so the card mirrors the production layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d590fd75e88327a4780b508f624de3