### PR TITLE
Expand desktop layout width and improve mobile wrapping

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -231,7 +231,7 @@ export default function Layout({ onLogout, theme, toggleTheme }: LayoutProps) {
         )}
 
         <main className="flex-1 md:ml-64">
-          <div className="w-full max-w-screen-lg mx-auto px-4 overflow-x-hidden py-4 sm:py-6 lg:py-8">
+          <div className="w-full max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 xl:px-10 2xl:px-12 overflow-x-hidden py-4 sm:py-6 lg:py-8">
             <Outlet />
           </div>
         </main>

--- a/src/pages/LeadsPage.tsx
+++ b/src/pages/LeadsPage.tsx
@@ -283,7 +283,10 @@ export default function LeadsPage() {
         </div>
 
         <div className="border-b border-gray-200 dark:border-[#1E1E1E] mb-6">
-          <nav className="-mb-px flex gap-4 sm:gap-8 overflow-x-auto" role="tablist">
+          <nav
+            className="-mb-px flex flex-wrap gap-2 sm:gap-4 lg:gap-6"
+            role="tablist"
+          >
             {[
               { id: 'resumo', label: 'Resumo' },
               { id: 'cadastro', label: 'Cadastro' },
@@ -297,7 +300,7 @@ export default function LeadsPage() {
                 onClick={() => setActiveTab(tab.id)}
                 role="tab"
                 aria-selected={activeTab === tab.id}
-                className={`shrink-0 whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm ${
+                className={`min-w-0 whitespace-normal text-center sm:text-left sm:whitespace-nowrap py-2 px-2 sm:px-3 border-b-2 font-medium text-sm leading-tight ${
                   activeTab === tab.id
                     ? 'border-yn-orange text-yn-orange dark:text-yn-orange'
                     : 'border-transparent text-gray-500 dark:text-gray-300 hover:text-gray-700 dark:hover:text-gray-100 hover:border-gray-300 dark:hover:border-[#1E1E1E]'

--- a/src/pages/LeadsSection.tsx
+++ b/src/pages/LeadsSection.tsx
@@ -13,14 +13,14 @@ export default function LeadsSection() {
       <div>
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Leads</h1>
         <div className="mt-4 overflow-x-auto">
-          <div className="inline-flex items-center gap-2 border-b border-gray-200 dark:border-[#2b3238] min-w-full">
+          <div className="flex flex-wrap items-center gap-2 border-b border-gray-200 dark:border-[#2b3238]">
             {tabs.map((t) => (
               <NavLink
                 key={t.to}
                 to={t.to}
                 end={(t as any).end}
                 className={({ isActive }) =>
-                  `px-3 sm:px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors whitespace-nowrap ${
+                  `px-3 sm:px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors min-w-0 whitespace-normal text-center sm:text-left sm:whitespace-nowrap ${
                     isActive
                       ? 'border-yn-orange text-yn-orange'
                       : 'border-transparent text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100'

--- a/src/pages/Negociacoes.tsx
+++ b/src/pages/Negociacoes.tsx
@@ -7,10 +7,10 @@ export default function Negociacoes() {
   const [tab, setTab] = useState<"leads" | "comissoes" | "metas">("leads");
 
   return (
-    <div className="mx-auto w-full max-w-[1200px]">
+    <div className="space-y-6">
       {/* Título */}
-      <div className="mb-6">
-        <h1 className="text-2xl font-extrabold text-gray-900 md:text-3xl">Negociações</h1>
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 md:text-3xl">Negociações</h1>
         <p className="text-sm text-gray-500 md:text-base">
           Central de acompanhamento de leads, comissões e metas
         </p>
@@ -18,8 +18,8 @@ export default function Negociacoes() {
 
       {/* Tabs */}
       <div className="rounded-xl bg-white shadow">
-        <div className="overflow-x-auto border-b border-gray-200">
-          <nav className="flex gap-4 px-4">
+        <div className="border-b border-gray-200">
+          <nav className="flex flex-wrap gap-2 sm:gap-4 px-4 py-2" role="tablist">
             <TabBtn
               icon={Users}
               label="Leads"
@@ -65,14 +65,14 @@ function TabBtn({
   return (
     <button
       onClick={onClick}
-      className={`flex shrink-0 items-center gap-2 border-b-2 px-2 py-3 text-sm font-semibold ${
+      className={`flex min-w-0 flex-1 items-center gap-2 border-b-2 px-2 py-2 text-sm font-semibold leading-tight sm:flex-initial sm:py-3 ${
         active
           ? "border-[#ff6b35] text-[#ff6b35]"
           : "border-transparent text-gray-500 hover:text-gray-700"
       }`}
     >
       <Icon size={18} />
-      <span className="whitespace-nowrap">{label}</span>
+      <span className="whitespace-normal break-words text-left sm:text-center sm:whitespace-nowrap">{label}</span>
     </button>
   );
 }

--- a/src/pages/OportunidadesPage.tsx
+++ b/src/pages/OportunidadesPage.tsx
@@ -5,13 +5,13 @@ export default function OportunidadesPage() {
   const [params] = useSearchParams();
   const mes = params.get('mes') || '';
   return (
-    <div className="p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Oportunidades de Contrato</h1>
-        <Link to="/dashboard" className="text-yn-orange">Voltar</Link>
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Oportunidades de Contrato</h1>
+        <Link to="/dashboard" className="text-yn-orange text-sm font-medium hover:underline">Voltar</Link>
       </div>
-      <div className="text-sm text-gray-600">Mês: {mes || 'atual'}</div>
-      <div className="border rounded p-4 bg-white dark:bg-[#1a1f24]">Lista completa (mock) a ser preenchida.</div>
+      <div className="text-sm text-gray-600 dark:text-gray-300">Mês: {mes || 'atual'}</div>
+      <div className="border rounded-lg p-4 bg-white dark:bg-[#1a1f24] shadow-sm">Lista completa (mock) a ser preenchida.</div>
     </div>
   );
 }

--- a/src/pages/negociacoes/LeadsKanban.tsx
+++ b/src/pages/negociacoes/LeadsKanban.tsx
@@ -145,7 +145,7 @@ export default function LeadsKanban() {
         </div>
         <button
           onClick={() => {}}
-          className="whitespace-nowrap rounded-lg bg-yn-orange px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-yn-orange/90"
+          className="min-w-0 whitespace-normal break-words rounded-lg bg-yn-orange px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-yn-orange/90 sm:whitespace-nowrap"
         >
           Enviar Fatura
         </button>


### PR DESCRIPTION
## Summary
- widen the shared layout container to use a broader max width with responsive padding on desktop
- align oportunidades and negociações page shells with the dashboard structure while allowing their tabs to wrap on smaller screens
- let leads section tabs, lead detail tabs, and kanban CTA buttons break lines on mobile to prevent truncated labels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbeceb97388327a801b747d7024992