### PR TITLE
Refactor contracts page to use mock data and new layout

### DIFF
--- a/src/mocks/contracts.ts
+++ b/src/mocks/contracts.ts
@@ -1,0 +1,539 @@
+export type StatusResumo = 'Conforme' | 'Divergente' | 'Em análise';
+export type AnaliseStatus = 'verde' | 'amarelo' | 'vermelho';
+
+export type KPIItem = {
+  label: string;
+  value: string;
+  helper?: string;
+  variation?: {
+    value: string;
+    direction: 'up' | 'down' | 'neutral';
+  };
+};
+
+export type ContractInfoField = {
+  label: string;
+  value: string;
+};
+
+export type DemandaHistorico = {
+  mes: string;
+  ponta: number;
+  foraPonta: number;
+};
+
+export type ConsumoHistorico = {
+  mes: string;
+  meta: number;
+  realizado: number;
+};
+
+export type ObrigacaoRow = {
+  periodo: string;
+  status: Record<string, StatusResumo>;
+};
+
+export type AnaliseArea = {
+  area: string;
+  etapas: Array<{
+    nome: 'Dados' | 'Cálculo' | 'Análise';
+    status: AnaliseStatus;
+    observacao?: string;
+  }>;
+};
+
+export type ContractMock = {
+  id: string;
+  codigo: string;
+  cliente: string;
+  cnpj: string;
+  segmento: string;
+  contato: string;
+  status: 'Ativo' | 'Inativo';
+  fonte: 'Convencional' | 'Incentivada';
+  modalidade: string;
+  inicioVigencia: string;
+  fimVigencia: string;
+  limiteSuperior: string;
+  limiteInferior: string;
+  flex: string;
+  precoMedio: number;
+  precoSpotReferencia: number;
+  cicloFaturamento: string;
+  periodos: string[]; // YYYY-MM
+  resumoConformidades: Record<'Consumo' | 'NF' | 'Fatura' | 'Encargos' | 'Conformidade', StatusResumo>;
+  kpis: KPIItem[];
+  dadosContrato: ContractInfoField[];
+  historicoDemanda: DemandaHistorico[];
+  historicoConsumo: ConsumoHistorico[];
+  obrigacoes: ObrigacaoRow[];
+  analises: AnaliseArea[];
+};
+
+const meses = ['2023-12', '2024-01', '2024-02', '2024-03', '2024-04', '2024-05', '2024-06'];
+
+const baseObrigacoesCols = [
+  'Consumo',
+  'NF',
+  'Fatura',
+  'Encargos',
+  'Conformidade',
+  'Divergências',
+  'Projeções',
+  'Riscos',
+  'Liquidação',
+  'Pagamentos',
+  'Preços',
+  'Flex',
+  'Limites',
+  'Documentos',
+  'Observações',
+];
+
+const obrigacoesRow = (periodo: string, statuses: StatusResumo[]): ObrigacaoRow => ({
+  periodo,
+  status: baseObrigacoesCols.reduce<Record<string, StatusResumo>>((acc, col, index) => {
+    acc[col] = statuses[index] ?? 'Conforme';
+    return acc;
+  }, {}),
+});
+
+export const obrigacaoColunas = ['Período', ...baseObrigacoesCols];
+
+export const mockContracts: ContractMock[] = [
+  {
+    id: 'US-11',
+    codigo: 'US-11',
+    cliente: 'UniSolar Energia',
+    cnpj: '12.345.678/0001-90',
+    segmento: 'Indústria Automotiva',
+    contato: 'Mariana Figueiredo',
+    status: 'Ativo',
+    fonte: 'Convencional',
+    modalidade: 'PLD Horário',
+    inicioVigencia: '2023-07-01',
+    fimVigencia: '2025-06-30',
+    limiteSuperior: '105%',
+    limiteInferior: '95%',
+    flex: '5%',
+    precoMedio: 274.32,
+    precoSpotReferencia: 312.45,
+    cicloFaturamento: '2024-06',
+    periodos: meses.slice(1),
+    resumoConformidades: {
+      Consumo: 'Conforme',
+      NF: 'Em análise',
+      Fatura: 'Conforme',
+      Encargos: 'Conforme',
+      Conformidade: 'Em análise',
+    },
+    kpis: [
+      { label: 'Consumo acumulado', value: '18.420 MWh', helper: 'Jan-Jun/2024' },
+      { label: 'Receita Prevista', value: 'R$ 5.9 mi', variation: { value: '+3,8%', direction: 'up' } },
+      { label: 'Economia vs Cativo', value: 'R$ 1.2 mi', variation: { value: '+12%', direction: 'up' } },
+      { label: 'Variação mensal', value: 'R$ 312 mil', variation: { value: '-1,5%', direction: 'down' } },
+    ],
+    dadosContrato: [
+      { label: 'Fornecedor', value: 'Neoenergia Comercializadora' },
+      { label: 'Vigência', value: 'Jul/2023 - Jun/2025' },
+      { label: 'Modalidade', value: 'Preço Fixo com Ajuste PLD' },
+      { label: 'Fonte', value: 'Convencional' },
+      { label: 'Volume Contratado', value: '3.200 MWh/mês' },
+      { label: 'Flex / Limites', value: '±5% (95% - 105%)' },
+      { label: 'Preço Médio', value: 'R$ 274,32 / MWh' },
+      { label: 'Preço Spot Ref.', value: 'R$ 312,45 / MWh' },
+      { label: 'Centro de Custo', value: 'Unidade Industrial SP' },
+      { label: 'Responsável', value: 'Mariana Figueiredo' },
+    ],
+    historicoDemanda: meses.slice(2).map((mes, index) => ({
+      mes,
+      ponta: 420 + index * 12,
+      foraPonta: 310 + index * 15,
+    })),
+    historicoConsumo: meses.slice(2).map((mes, index) => ({
+      mes,
+      meta: 3200,
+      realizado: 3100 + (index % 2 === 0 ? 80 : -120),
+    })),
+    obrigacoes: [
+      obrigacoesRow('Fev/2024', [
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+      ]),
+      obrigacoesRow('Mar/2024', [
+        'Conforme',
+        'Divergente',
+        'Conforme',
+        'Conforme',
+        'Divergente',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+      ]),
+      obrigacoesRow('Abr/2024', [
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+      ]),
+    ],
+    analises: [
+      {
+        area: 'Consumo',
+        etapas: [
+          { nome: 'Dados', status: 'verde' },
+          { nome: 'Cálculo', status: 'amarelo', observacao: 'Aguardando medição da distribuidora' },
+          { nome: 'Análise', status: 'amarelo' },
+        ],
+      },
+      {
+        area: 'NF',
+        etapas: [
+          { nome: 'Dados', status: 'verde' },
+          { nome: 'Cálculo', status: 'verde' },
+          { nome: 'Análise', status: 'vermelho', observacao: 'Diferença ICMS em revisão' },
+        ],
+      },
+      {
+        area: 'Fatura',
+        etapas: [
+          { nome: 'Dados', status: 'verde' },
+          { nome: 'Cálculo', status: 'verde' },
+          { nome: 'Análise', status: 'verde' },
+        ],
+      },
+      {
+        area: 'Encargos',
+        etapas: [
+          { nome: 'Dados', status: 'amarelo' },
+          { nome: 'Cálculo', status: 'amarelo', observacao: 'Verificando ajustes MCP' },
+          { nome: 'Análise', status: 'verde' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'BR-04',
+    codigo: 'BR-04',
+    cliente: 'Brasil Foods LTDA',
+    cnpj: '98.765.432/0001-10',
+    segmento: 'Alimentos',
+    contato: 'Renato Magalhães',
+    status: 'Ativo',
+    fonte: 'Incentivada',
+    modalidade: 'Desconto TUSD Verde',
+    inicioVigencia: '2022-01-01',
+    fimVigencia: '2024-12-31',
+    limiteSuperior: '110%',
+    limiteInferior: '92%',
+    flex: '8%',
+    precoMedio: 219.5,
+    precoSpotReferencia: 245.82,
+    cicloFaturamento: '2024-05',
+    periodos: meses.slice(0, 6),
+    resumoConformidades: {
+      Consumo: 'Conforme',
+      NF: 'Conforme',
+      Fatura: 'Em análise',
+      Encargos: 'Conforme',
+      Conformidade: 'Conforme',
+    },
+    kpis: [
+      { label: 'Consumo acumulado', value: '14.760 MWh', helper: 'Jan-Mai/2024' },
+      { label: 'Receita Prevista', value: 'R$ 4.4 mi', variation: { value: '+1,2%', direction: 'up' } },
+      { label: 'Economia vs Cativo', value: 'R$ 980 mil', variation: { value: '+6,3%', direction: 'up' } },
+      { label: 'Variação mensal', value: 'R$ 214 mil', variation: { value: '+0,4%', direction: 'neutral' } },
+    ],
+    dadosContrato: [
+      { label: 'Fornecedor', value: 'Raízen Energia' },
+      { label: 'Vigência', value: 'Jan/2022 - Dez/2024' },
+      { label: 'Modalidade', value: 'TUSD Verde' },
+      { label: 'Fonte', value: 'Incentivada' },
+      { label: 'Volume Contratado', value: '2.450 MWh/mês' },
+      { label: 'Flex / Limites', value: '±8% (92% - 110%)' },
+      { label: 'Preço Médio', value: 'R$ 219,50 / MWh' },
+      { label: 'Preço Spot Ref.', value: 'R$ 245,82 / MWh' },
+      { label: 'Centro de Custo', value: 'Planta RS' },
+      { label: 'Responsável', value: 'Renato Magalhães' },
+    ],
+    historicoDemanda: meses.slice(1, 6).map((mes, index) => ({
+      mes,
+      ponta: 280 + index * 9,
+      foraPonta: 210 + index * 6,
+    })),
+    historicoConsumo: meses.slice(1, 6).map((mes, index) => ({
+      mes,
+      meta: 2450,
+      realizado: 2400 + (index % 3 === 0 ? 60 : -70),
+    })),
+    obrigacoes: [
+      obrigacoesRow('Jan/2024', [
+        'Conforme',
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+      ]),
+      obrigacoesRow('Fev/2024', [
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+      ]),
+      obrigacoesRow('Mar/2024', [
+        'Em análise',
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Em análise',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+      ]),
+    ],
+    analises: [
+      {
+        area: 'Consumo',
+        etapas: [
+          { nome: 'Dados', status: 'verde' },
+          { nome: 'Cálculo', status: 'verde' },
+          { nome: 'Análise', status: 'verde' },
+        ],
+      },
+      {
+        area: 'NF',
+        etapas: [
+          { nome: 'Dados', status: 'verde' },
+          { nome: 'Cálculo', status: 'verde' },
+          { nome: 'Análise', status: 'verde' },
+        ],
+      },
+      {
+        area: 'Fatura',
+        etapas: [
+          { nome: 'Dados', status: 'amarelo' },
+          { nome: 'Cálculo', status: 'amarelo', observacao: 'Recalculando demanda contratada' },
+          { nome: 'Análise', status: 'amarelo' },
+        ],
+      },
+      {
+        area: 'Encargos',
+        etapas: [
+          { nome: 'Dados', status: 'verde' },
+          { nome: 'Cálculo', status: 'verde' },
+          { nome: 'Análise', status: 'verde' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'MG-21',
+    codigo: 'MG-21',
+    cliente: 'Minas Gusa Siderurgia',
+    cnpj: '45.908.321/0001-05',
+    segmento: 'Siderurgia',
+    contato: 'Larissa Campos',
+    status: 'Ativo',
+    fonte: 'Convencional',
+    modalidade: 'Preço Fixo',
+    inicioVigencia: '2024-01-01',
+    fimVigencia: '2026-12-31',
+    limiteSuperior: '108%',
+    limiteInferior: '93%',
+    flex: '7%',
+    precoMedio: 252.9,
+    precoSpotReferencia: 271.1,
+    cicloFaturamento: '2024-06',
+    periodos: meses.slice(2),
+    resumoConformidades: {
+      Consumo: 'Em análise',
+      NF: 'Conforme',
+      Fatura: 'Conforme',
+      Encargos: 'Em análise',
+      Conformidade: 'Em análise',
+    },
+    kpis: [
+      { label: 'Consumo acumulado', value: '9.870 MWh', helper: 'Jan-Jun/2024' },
+      { label: 'Receita Prevista', value: 'R$ 3.1 mi', variation: { value: '+2,1%', direction: 'up' } },
+      { label: 'Economia vs Cativo', value: 'R$ 640 mil', variation: { value: '+4,4%', direction: 'up' } },
+      { label: 'Variação mensal', value: 'R$ 198 mil', variation: { value: '+0,8%', direction: 'up' } },
+    ],
+    dadosContrato: [
+      { label: 'Fornecedor', value: 'Brookfield Energia' },
+      { label: 'Vigência', value: 'Jan/2024 - Dez/2026' },
+      { label: 'Modalidade', value: 'Preço Fixo' },
+      { label: 'Fonte', value: 'Convencional' },
+      { label: 'Volume Contratado', value: '1.650 MWh/mês' },
+      { label: 'Flex / Limites', value: '±7% (93% - 108%)' },
+      { label: 'Preço Médio', value: 'R$ 252,90 / MWh' },
+      { label: 'Preço Spot Ref.', value: 'R$ 271,10 / MWh' },
+      { label: 'Centro de Custo', value: 'Planta MG' },
+      { label: 'Responsável', value: 'Larissa Campos' },
+    ],
+    historicoDemanda: meses.slice(2).map((mes, index) => ({
+      mes,
+      ponta: 190 + index * 7,
+      foraPonta: 150 + index * 10,
+    })),
+    historicoConsumo: meses.slice(2).map((mes, index) => ({
+      mes,
+      meta: 1650,
+      realizado: 1600 + (index % 2 === 0 ? -40 : 70),
+    })),
+    obrigacoes: [
+      obrigacoesRow('Fev/2024', [
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+        'Em análise',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+      ]),
+      obrigacoesRow('Mar/2024', [
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+        'Em análise',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+      ]),
+      obrigacoesRow('Abr/2024', [
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Em análise',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+        'Conforme',
+      ]),
+    ],
+    analises: [
+      {
+        area: 'Consumo',
+        etapas: [
+          { nome: 'Dados', status: 'amarelo', observacao: 'Medição parcial recebida' },
+          { nome: 'Cálculo', status: 'amarelo' },
+          { nome: 'Análise', status: 'amarelo' },
+        ],
+      },
+      {
+        area: 'NF',
+        etapas: [
+          { nome: 'Dados', status: 'verde' },
+          { nome: 'Cálculo', status: 'verde' },
+          { nome: 'Análise', status: 'verde' },
+        ],
+      },
+      {
+        area: 'Fatura',
+        etapas: [
+          { nome: 'Dados', status: 'verde' },
+          { nome: 'Cálculo', status: 'verde' },
+          { nome: 'Análise', status: 'verde' },
+        ],
+      },
+      {
+        area: 'Encargos',
+        etapas: [
+          { nome: 'Dados', status: 'amarelo' },
+          { nome: 'Cálculo', status: 'amarelo', observacao: 'Ajuste GFOM' },
+          { nome: 'Análise', status: 'vermelho', observacao: 'Pendências MCP' },
+        ],
+      },
+    ],
+  },
+];
+
+export function formatMesLabel(periodo: string) {
+  const [ano, mes] = periodo.split('-').map(Number);
+  if (!ano || !mes) return periodo;
+  return new Date(ano, mes - 1).toLocaleDateString('pt-BR', {
+    month: 'short',
+    year: 'numeric',
+  });
+}

--- a/src/pages/contratos/ContractDetail.tsx
+++ b/src/pages/contratos/ContractDetail.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type {
+  ContractMock,
+  StatusResumo,
+  AnaliseStatus,
+} from '../../mocks/contracts';
+import { obrigacaoColunas, formatMesLabel } from '../../mocks/contracts';
+
+const statusStyles: Record<StatusResumo, string> = {
+  Conforme: 'bg-green-100 text-green-700 border border-green-200',
+  'Divergente': 'bg-red-100 text-red-700 border border-red-200',
+  'Em análise': 'bg-yellow-100 text-yellow-700 border border-yellow-200',
+};
+
+const analiseStyles: Record<AnaliseStatus, string> = {
+  verde: 'bg-green-500',
+  amarelo: 'bg-yellow-400',
+  vermelho: 'bg-red-500',
+};
+
+const variationColors: Record<'up' | 'down' | 'neutral', string> = {
+  up: 'text-emerald-600',
+  down: 'text-red-600',
+  neutral: 'text-gray-500',
+};
+
+const variationSymbol: Record<'up' | 'down' | 'neutral', string> = {
+  up: '▲',
+  down: '▼',
+  neutral: '■',
+};
+
+function formatMonth(periodo: string) {
+  return formatMesLabel(periodo).replace('.', '');
+}
+
+type Props = {
+  contrato: ContractMock;
+};
+
+export function StatusBadge({ status }: { status: StatusResumo }) {
+  return <span className={`px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap ${statusStyles[status]}`}>{status}</span>;
+}
+
+export const ContractDetail: React.FC<Props> = ({ contrato }) => {
+  return (
+    <div className="space-y-6">
+      <section aria-labelledby="indicadores" className="bg-white rounded-xl border border-gray-100 shadow-sm">
+        <div className="border-b border-gray-100 px-4 py-3">
+          <h2 id="indicadores" className="text-base font-semibold text-gray-900">
+            Indicadores / KPIs
+          </h2>
+        </div>
+        <div className="grid grid-cols-1 gap-4 p-4 sm:grid-cols-2 lg:grid-cols-4">
+          {contrato.kpis.map((item) => (
+            <div
+              key={item.label}
+              className="rounded-lg border border-gray-100 bg-gray-50 p-4 text-sm shadow-sm transition hover:border-yn-orange/60 hover:shadow"
+            >
+              <div className="text-gray-500">{item.label}</div>
+              <div className="mt-2 text-lg font-semibold text-gray-900">{item.value}</div>
+              <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
+                {item.helper && <span>{item.helper}</span>}
+                {item.variation && (
+                  <span className={`font-semibold ${variationColors[item.variation.direction]}`}>
+                    {variationSymbol[item.variation.direction]} {item.variation.value}
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="dados-contrato" className="bg-white rounded-xl border border-gray-100 shadow-sm">
+        <div className="border-b border-gray-100 px-4 py-3">
+          <h2 id="dados-contrato" className="text-base font-semibold text-gray-900">
+            Dados do Contrato
+          </h2>
+        </div>
+        <dl className="grid grid-cols-1 gap-x-6 gap-y-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
+          {contrato.dadosContrato.map((field) => (
+            <div key={field.label} className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+              <dt className="text-xs font-medium uppercase tracking-wide text-gray-500">{field.label}</dt>
+              <dd className="mt-1 text-sm font-semibold text-gray-900">{field.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+
+      <section aria-labelledby="historico" className="space-y-4">
+        <h2 id="historico" className="text-base font-semibold text-gray-900">
+          Histórico
+        </h2>
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm">
+            <h3 className="text-sm font-medium text-gray-900">Histórico de Demanda</h3>
+            <p className="text-xs text-gray-500">Comparativo de demanda ponta e fora-ponta</p>
+            <div className="h-60 pt-2">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={contrato.historicoDemanda}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <XAxis dataKey="mes" tickFormatter={formatMonth} fontSize={11} stroke="#6b7280" />
+                  <YAxis fontSize={11} stroke="#6b7280" />
+                  <Tooltip
+                    labelFormatter={(label) => formatMonth(String(label))}
+                    contentStyle={{ fontSize: '0.75rem', borderRadius: '0.75rem' }}
+                  />
+                  <Legend wrapperStyle={{ fontSize: '0.75rem' }} />
+                  <Line type="monotone" dataKey="ponta" name="Ponta" stroke="#f97316" strokeWidth={2} dot={false} />
+                  <Line type="monotone" dataKey="foraPonta" name="Fora-Ponta" stroke="#0ea5e9" strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+          <div className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm">
+            <h3 className="text-sm font-medium text-gray-900">Histórico de Consumo</h3>
+            <p className="text-xs text-gray-500">Meta vs realizado (MWh)</p>
+            <div className="h-60 pt-2">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={contrato.historicoConsumo}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <XAxis dataKey="mes" tickFormatter={formatMonth} fontSize={11} stroke="#6b7280" />
+                  <YAxis fontSize={11} stroke="#6b7280" />
+                  <Tooltip
+                    labelFormatter={(label) => formatMonth(String(label))}
+                    contentStyle={{ fontSize: '0.75rem', borderRadius: '0.75rem' }}
+                  />
+                  <Legend wrapperStyle={{ fontSize: '0.75rem' }} />
+                  <Line type="monotone" dataKey="meta" name="Meta" stroke="#22c55e" strokeWidth={2} dot={false} />
+                  <Line type="monotone" dataKey="realizado" name="Realizado" stroke="#6366f1" strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="obrigacoes" className="bg-white rounded-xl border border-gray-100 shadow-sm">
+        <div className="border-b border-gray-100 px-4 py-3">
+          <h2 id="obrigacoes" className="text-base font-semibold text-gray-900">
+            Obrigações &amp; Status
+          </h2>
+        </div>
+        <div className="overflow-auto">
+          <table className="min-w-[960px] w-full table-auto divide-y divide-gray-100 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                {obrigacaoColunas.map((col) => (
+                  <th key={col} className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 bg-white">
+              {contrato.obrigacoes.map((linha) => (
+                <tr key={linha.periodo} className="hover:bg-gray-50">
+                  <td className="whitespace-nowrap px-3 py-2 text-sm font-medium text-gray-900">{linha.periodo}</td>
+                  {obrigacaoColunas.slice(1).map((col) => (
+                    <td key={col} className="px-3 py-2">
+                      <StatusBadge status={linha.status[col]} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section aria-labelledby="indicadores-analises" className="bg-white rounded-xl border border-gray-100 shadow-sm">
+        <div className="border-b border-gray-100 px-4 py-3">
+          <h2 id="indicadores-analises" className="text-base font-semibold text-gray-900">
+            Indicadores de Análises
+          </h2>
+        </div>
+        <div className="grid grid-cols-1 gap-4 p-4 md:grid-cols-2 xl:grid-cols-4">
+          {contrato.analises.map((area) => (
+            <div key={area.area} className="rounded-lg border border-gray-100 bg-gray-50 p-4 shadow-sm">
+              <div className="mb-3 text-sm font-semibold text-gray-900">{area.area}</div>
+              <ol className="space-y-2 text-xs text-gray-600">
+                {area.etapas.map((etapa) => (
+                  <li key={etapa.nome} className="flex items-center justify-between gap-4 rounded-md bg-white px-3 py-2 shadow-sm">
+                    <div className="flex items-center gap-2">
+                      <span className={`inline-block h-2.5 w-2.5 rounded-full ${analiseStyles[etapa.status]}`} aria-hidden />
+                      <span className="font-medium text-gray-800">{etapa.nome}</span>
+                    </div>
+                    {etapa.observacao && <span className="text-[11px] text-gray-500">{etapa.observacao}</span>}
+                  </li>
+                ))}
+              </ol>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/pages/contratos/DetalheContrato.tsx
+++ b/src/pages/contratos/DetalheContrato.tsx
@@ -1,368 +1,45 @@
-﻿import React from 'react';
-import { useParams, Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, Brush, ResponsiveContainer, Legend } from 'recharts';
-
-type DetalheResponse = {
-  dados_contrato: {
-    vigencia: { inicio: string; fim: string };
-    fornecedor: string;
-    fonte: 'Convencional' | 'Incentivada';
-    preco_contratado: number;
-    preco_reajustado: number;
-    volume_total: number;
-    sazonalizacao?: Record<string, number>;
-    flexibilidade_pct: number;
-  };
-  financeiros: {
-    economia_acumulada: number;
-    custo_por_origem: { livre: number; cativo: number; encargos: number };
-    bandeira_atual: string;
-    tarifas: { te: number; tusd: number };
-  };
-  nf_fornecedora: {
-    valor_nf_energia: number;
-    valor_calculado_energia: number;
-    status_energia: 'Conforme' | 'Divergente';
-    valor_documento_icms: number;
-    detalhes_icms?: string;
-    status_icms: 'Conforme' | 'Divergente';
-  };
-  fatura_distribuidora: {
-    demanda_cobrada: number;
-    demanda_contratada: number;
-    regra_pct_tolerancia: 1.05;
-    status: 'Conforme' | 'Divergente';
-    observacao?: string;
-  };
-  status_conformidades_resumo: {
-    nf_fornecedora: 'Conforme' | 'Divergente' | 'Indefinido';
-    fatura_distribuidora: 'Conforme' | 'Divergente';
-  };
-  indicadores: Array<{ tipo: 'DEMANDA' | 'MODALIDADE_TARIFARIA' | 'ENERGIA_REATIVA' | 'CONTRATO'; status: 'verde' | 'amarelo' | 'vermelho'; mensagem: string; acao?: { tipo: 'abrir_modal' | 'link'; rotulo: string; url?: string; modalId?: string; } }>;
-};
-
-type SerieResponse = { pontos: Array<{ competencia: string; valor: number }> };
-
-function Money({ value }: { value: number }) {
-  return <>{value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</>;
-}
-
-function Card({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className="border rounded-lg bg-white dark:bg-[#1a1f24]">
-      <div className="px-4 py-2 border-b dark:border-[#2b3238] text-sm font-medium">{title}</div>
-      <div className="p-4">{children}</div>
-    </div>
-  );
-}
+import React from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { ContractDetail } from './ContractDetail';
+import { mockContracts } from '../../mocks/contracts';
 
 export default function DetalheContratoPage() {
-  const [modal, setModal] = React.useState<{ open: boolean; title?: string; modalId?: string }>({ open: false });
   const { id } = useParams();
+  const contrato = React.useMemo(() => mockContracts.find((item) => item.id === id), [id]);
 
-  const { data, isLoading, isError, refetch } = useQuery<DetalheResponse>({
-    queryKey: ['contrato', id],
-    queryFn: async () => {
-      const res = await fetch(`/api/contratos/${id}`);
-      if (!res.ok) throw new Error('Erro');
-      return res.json();
-    },
-  });
-
-  const demandaQ = useQuery<SerieResponse>({
-    queryKey: ['contrato-ciclos', id, 'demanda'],
-    queryFn: async () => {
-      const res = await fetch(`/api/contratos/${id}/ciclos?serie=demanda`);
-      if (!res.ok) throw new Error('Erro');
-      return res.json();
-    },
-  });
-
-  const consumoQ = useQuery<SerieResponse>({
-    queryKey: ['contrato-ciclos', id, 'consumo'],
-    queryFn: async () => {
-      const res = await fetch(`/api/contratos/${id}/ciclos?serie=consumo`);
-      if (!res.ok) throw new Error('Erro');
-      return res.json();
-    },
-  });
-
-  if (isLoading) {
+  if (!contrato) {
     return (
-      <div className="space-y-4">
-        <div className="h-6 w-48 bg-gray-200 dark:bg-gray-700 animate-pulse rounded" />
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="border rounded-lg p-4">
-              <div className="h-5 w-32 bg-gray-200 dark:bg-gray-700 animate-pulse mb-4" />
-              <div className="h-24 bg-gray-100 dark:bg-gray-800 animate-pulse" />
-            </div>
-          ))}
-        </div>
+      <div className="space-y-4 p-6">
+        <h1 className="text-xl font-semibold text-gray-900">Contrato não encontrado</h1>
+        <p className="text-sm text-gray-600">
+          Não foi possível localizar o contrato selecionado. Retorne à lista de contratos e tente novamente.
+        </p>
+        <Link
+          to="/contratos"
+          className="inline-flex items-center justify-center rounded-lg border border-yn-orange px-4 py-2 text-sm font-medium text-yn-orange shadow-sm transition hover:bg-yn-orange hover:text-white"
+        >
+          Voltar para contratos
+        </Link>
       </div>
     );
   }
-
-  if (isError || !data) {
-    return (
-      <div className="p-4" aria-live="assertive">
-        <p className="text-red-600 mb-2">Falha ao carregar detalhes do contrato.</p>
-        <button onClick={() => refetch()} className="px-3 py-1 border rounded">Tentar novamente</button>
-      </div>
-    );
-  }
-
-  const { dados_contrato: dc, financeiros: fin, status_conformidades_resumo: st, nf_fornecedora, fatura_distribuidora } = data;
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">Contrato {id}</h1>
-        <Link to="/contratos" className="text-sm text-yn-orange">Voltar</Link>
-      </div>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {/* 1) Indicadores Financeiros e de Custos */}
-        <Card title="Indicadores Financeiros e de Custos">
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div>
-              <div className="text-gray-500">Economia Acumulada</div>
-              <div className="text-lg font-semibold"><Money value={fin.economia_acumulada} /></div>
-            </div>
-            <div>
-              <div className="text-gray-500">Bandeira Atual</div>
-              <div className="text-lg font-semibold">{fin.bandeira_atual}</div>
-            </div>
-            <div>
-              <div className="text-gray-500">Custos - Livre</div>
-              <div><Money value={fin.custo_por_origem.livre} /></div>
-            </div>
-            <div>
-              <div className="text-gray-500">Custos - Cativo</div>
-              <div><Money value={fin.custo_por_origem.cativo} /></div>
-            </div>
-            <div>
-              <div className="text-gray-500">Custos - Encargos</div>
-              <div><Money value={fin.custo_por_origem.encargos} /></div>
-            </div>
-            <div>
-              <div className="text-gray-500">Tarifas (TE/TUSD)</div>
-              <div>{fin.tarifas.te.toFixed(3)} / {fin.tarifas.tusd.toFixed(3)}</div>
-            </div>
-          </div>
-        </Card>
-
-        {/* Conformidades */}
-        <Card title="Conformidades - NF Fornecedora">
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div>
-              <div className="text-gray-500">Valor NF Energia</div>
-              <div className="font-medium"><Money value={nf_fornecedora.valor_nf_energia} /></div>
-            </div>
-            <div>
-              <div className="text-gray-500">Valor Calculado Energia</div>
-              <div className="font-medium"><Money value={nf_fornecedora.valor_calculado_energia} /></div>
-            </div>
-            <div className="col-span-2">
-              <div className="text-gray-500">Status Energia</div>
-              <div>
-                <span className={`px-2 py-1 rounded text-xs ${nf_fornecedora.status_energia==='Conforme'?'bg-green-100 text-green-700':'bg-red-100 text-red-700'}`}>{nf_fornecedora.status_energia}</span>
-              </div>
-            </div>
-            <div>
-              <div className="text-gray-500">Valor Documento ICMS</div>
-              <div className="font-medium"><Money value={nf_fornecedora.valor_documento_icms} /></div>
-            </div>
-            <div>
-              <div className="text-gray-500">Status ICMS</div>
-              <div>
-                <span className={`px-2 py-1 rounded text-xs ${nf_fornecedora.status_icms==='Conforme'?'bg-green-100 text-green-700':'bg-red-100 text-red-700'}`}>{nf_fornecedora.status_icms}</span>
-              </div>
-            </div>
-            {nf_fornecedora.detalhes_icms && (
-              <div className="col-span-2 text-red-700 bg-red-50 rounded p-2" role="note">
-                {nf_fornecedora.detalhes_icms}
-              </div>
-            )}
-          </div>
-        </Card>
-
-        <Card title="Conformidades - Fatura Distribuidora">
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div>
-              <div className="text-gray-500">Demanda Cobrada</div>
-              <div className="font-medium">{fatura_distribuidora.demanda_cobrada.toFixed(2)}</div>
-            </div>
-            <div>
-              <div className="text-gray-500">Demanda Contratada</div>
-              <div className="font-medium">{fatura_distribuidora.demanda_contratada.toFixed(2)}</div>
-            </div>
-            <div>
-              <div className="text-gray-500">Tolerância</div>
-              <div className="font-medium">{Math.round((fatura_distribuidora.regra_pct_tolerancia - 1) * 100)}%</div>
-            </div>
-            <div>
-              <div className="text-gray-500">Status</div>
-              <div>
-                <span className={`px-2 py-1 rounded text-xs ${fatura_distribuidora.status==='Conforme'?'bg-green-100 text-green-700':'bg-red-100 text-red-700'}`}>{fatura_distribuidora.status}</span>
-              </div>
-            </div>
-            {fatura_distribuidora.observacao && (
-              <div className="col-span-2 text-red-700 bg-red-50 rounded p-2" role="note">
-                {fatura_distribuidora.observacao}
-              </div>
-            )}
-          </div>
-        </Card>
-
-        {/* 2) Dados do Contrato */}
-        <Card title="Dados do Contrato">
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div>
-              <div className="text-gray-500">Vigência</div>
-              <div>{dc.vigencia.inicio} a {dc.vigencia.fim}</div>
-            </div>
-            <div>
-              <div className="text-gray-500">Fornecedor</div>
-              <div>{dc.fornecedor}</div>
-            </div>
-            <div>
-              <div className="text-gray-500">Fonte</div>
-              <div>{dc.fonte}</div>
-            </div>
-            <div>
-              <div className="text-gray-500">Preço (Contratado / Reajustado)</div>
-              <div><Money value={dc.preco_contratado} /> / <Money value={dc.preco_reajustado} /></div>
-            </div>
-            <div>
-              <div className="text-gray-500">Volume Total</div>
-              <div>{dc.volume_total} MWh</div>
-            </div>
-            <div>
-              <div className="text-gray-500">Flexibilidade</div>
-              <div>{(dc.flexibilidade_pct*100).toFixed(0)}%</div>
-            </div>
-          </div>
-          {dc.sazonalizacao && (
-            <div className="mt-4 text-xs text-gray-500">Sazonalização informada</div>
-          )}
-          <div className="mt-4 text-sm">
-            <span className="mr-2">NF Fornecedora:</span>
-            <span className={`px-2 py-1 rounded text-xs ${st.nf_fornecedora==='Conforme'?'bg-green-100 text-green-700': st.nf_fornecedora==='Divergente'?'bg-red-100 text-red-700':'bg-gray-100 text-gray-700'}`}>{st.nf_fornecedora}</span>
-            <span className="ml-4 mr-2">Fatura Distribuidora:</span>
-            <span className={`px-2 py-1 rounded text-xs ${st.fatura_distribuidora==='Conforme'?'bg-green-100 text-green-700':'bg-red-100 text-red-700'}`}>{st.fatura_distribuidora}</span>
-          </div>
-        </Card>
-
-        {/* 3) Gráfico Demanda */}
-        <Card title="Histórico de Demanda">
-          {demandaQ.isLoading ? (
-            <div className="h-48 bg-gray-100 dark:bg-gray-800 animate-pulse" />
-          ) : demandaQ.isError ? (
-            <div className="text-red-600" aria-live="assertive">Falha ao carregar demanda.</div>
-          ) : (
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={demandaQ.data?.pontos} margin={{ left: 8, right: 8, top: 8, bottom: 8 }}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="competencia" tick={{ fontSize: 12 }} />
-                  <YAxis tick={{ fontSize: 12 }} />
-                  <Tooltip />
-                  <Legend />
-                  <Line type="monotone" dataKey="valor" stroke="#f97316" dot={false} name="Demanda" />
-                  <Brush dataKey="competencia" height={20} stroke="#f97316" />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-          )}
-        </Card>
-
-        {/* 4) Gráfico Consumo */}
-        <Card title="Histórico de Consumo">
-          {consumoQ.isLoading ? (
-            <div className="h-48 bg-gray-100 dark:bg-gray-800 animate-pulse" />
-          ) : consumoQ.isError ? (
-            <div className="text-red-600" aria-live="assertive">Falha ao carregar consumo.</div>
-          ) : (
-            <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={consumoQ.data?.pontos} margin={{ left: 8, right: 8, top: 8, bottom: 8 }}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="competencia" tick={{ fontSize: 12 }} />
-                  <YAxis tick={{ fontSize: 12 }} />
-                  <Tooltip />
-                  <Legend />
-                  <Line type="monotone" dataKey="valor" stroke="#2563eb" dot={false} name="Consumo" />
-                  <Brush dataKey="competencia" height={20} stroke="#2563eb" />
-                </LineChart>
-              </ResponsiveContainer>
-            </div>
-          )}
-        </Card>
-      </div>
-
-      {/* 5) Inteligência do Contrato */}
-      <div className="space-y-2">
-        <h2 className="text-lg font-semibold">Inteligência do Contrato</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-          {data.indicadores?.map((ind, idx) => (
-            <div key={idx} className="border rounded-lg bg-white dark:bg-[#1a1f24]">
-              <div className="px-4 py-2 border-b dark:border-[#2b3238] text-sm font-medium flex items-center justify-between">
-                <span>{labelTipo(ind.tipo)}</span>
-                <span role="status" aria-label={`status ${ind.status}`} className={`px-2 py-0.5 rounded text-xs ${badgeClasses(ind.status)}`}>{ind.status}</span>
-              </div>
-              <div className="p-4 text-sm space-y-3">
-                <p>{ind.mensagem}</p>
-                {ind.acao?.tipo === 'abrir_modal' && (
-                  <button className="px-3 py-1 rounded bg-yn-orange text-white" onClick={() => setModal({ open: true, title: labelTipo(ind.tipo), modalId: ind.acao?.modalId })}>
-                    {ind.acao.rotulo}
-                  </button>
-                )}
-                {ind.acao?.tipo === 'link' && ind.acao.url && (
-                  <a className="px-3 py-1 inline-block rounded bg-yn-orange text-white" href={ind.acao.url} target="_blank" rel="noopener">
-                    {ind.acao.rotulo}
-                  </a>
-                )}
-              </div>
-            </div>
-          ))}
+    <div className="space-y-6 p-4">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Contrato {contrato.codigo}</h1>
+          <p className="text-sm text-gray-600">{contrato.cliente} · CNPJ {contrato.cnpj}</p>
         </div>
-      </div>
+        <Link
+          to="/contratos"
+          className="inline-flex items-center justify-center rounded-lg border border-yn-orange px-4 py-2 text-sm font-medium text-yn-orange shadow-sm transition hover:bg-yn-orange hover:text-white"
+        >
+          Voltar para contratos
+        </Link>
+      </header>
 
-      {modal.open && (
-        <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-white dark:bg-[#1a1f24] rounded-lg shadow-lg max-w-md w-full p-4">
-            <div className="flex items-center justify-between mb-2">
-              <h3 className="text-lg font-semibold">{modal.title}</h3>
-              <button aria-label="Fechar" className="px-2 py-1" onClick={() => setModal({ open: false })}>?</button>
-            </div>
-            <div className="text-sm text-gray-600 dark:text-gray-300">
-              Conteúdo do modal (placeholder) - ID: {modal.modalId}
-            </div>
-            <div className="mt-4 text-right">
-              <button className="px-3 py-1 rounded border" onClick={() => setModal({ open: false })}>Fechar</button>
-            </div>
-          </div>
-        </div>
-      )}
+      <ContractDetail contrato={contrato} />
     </div>
   );
-}
-
-function badgeClasses(status) {
-  return status === 'verde'
-    ? 'bg-green-100 text-green-700'
-    : status === 'amarelo'
-    ? 'bg-yellow-100 text-yellow-700'
-    : 'bg-red-100 text-red-700';
-}
-
-function labelTipo(t) {
-  switch (t) {
-    case 'DEMANDA': return 'Demanda';
-    case 'MODALIDADE_TARIFARIA': return 'Modalidade Tarifária';
-    case 'ENERGIA_REATIVA': return 'Energia Reativa';
-    case 'CONTRATO': return 'Contrato';
-  }
 }


### PR DESCRIPTION
## Summary
- replace the contracts list with a mock-driven implementation featuring period filtering, ordering, and pagination
- add a reusable contract detail component that surfaces KPIs, contract data, history charts, obligations, and analysis indicators with fake data
- update the dedicated contract detail route to rely on the same mock dataset

## Testing
- npm run test *(fails: ReferenceError: expect is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfa688eb48327a68cd1de9298d4a3