### PR TITLE
Move invoice upload to energy balance page and add client search

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,7 @@ import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import Layout from './components/Layout';
 import { useTheme } from './hooks/useTheme';
 import DashboardPage from './pages/DashboardPage';
-import LeadsPage from './pages/LeadsPage';
-import LeadsSection from './pages/LeadsSection';
 import AgendaPage from './pages/AgendaPage';
-import ProposalsPage from './pages/ProposalsPage';
 import CommissionsPage from './pages/CommissionsPage';
 import ProfilePage from './pages/ProfilePage';
 import RankingPage from './pages/Ranking';
@@ -56,12 +53,9 @@ function AppRoutes() {
             <Route path="contratos/:id" element={<DetalheContratoPage />} />
 
             {/* Conteúdo legado do portal de consultores (pode ser ajustado por role no futuro) */}
-            <Route path="leads" element={<LeadsSection />}>
-              <Route index element={<LeadsPage />} />
-              <Route path="proposals" element={<ProposalsPage />} />
-              <Route path="simulation" element={<SimulationClientsPage />} />
-              <Route path="simulation/:clientId" element={<SimulationClientPage />} />
-            </Route>
+            <Route path="leads" element={<Navigate to="/leads/simulation" replace />} />
+            <Route path="leads/simulation" element={<SimulationClientsPage />} />
+            <Route path="leads/simulation/:clientId" element={<SimulationClientPage />} />
             <Route path="agenda" element={<AgendaPage />} />
             <Route path="commissions" element={<CommissionsPage />} />
             <Route path="profile" element={<ProfilePage />} />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -16,12 +16,11 @@ import {
 } from 'lucide-react';
 import CrownIcon from './icons/CrownIcon';
 import { mockUser } from '../data/mockData';
-import UploadXLSX from './UploadXLSX';
 
 const navigation = [
   { to: '/dashboard', label: 'Dashboard', icon: Home },
   { to: '/contratos', label: 'Contratos', icon: PieChart },
-  { to: '/leads', label: 'Leads', icon: FileText },
+  { to: '/leads/simulation', label: 'Balanço Energético', icon: FileText },
   /* { to: '/negociacoes', label: 'Negociações', icon: Handshake }, */
   /* { to: '/agenda', label: 'Agenda', icon: Calendar }, */
   { to: '/profile', label: 'Perfil', icon: User },
@@ -85,7 +84,6 @@ export default function Layout({ onLogout, theme, toggleTheme }: LayoutProps) {
             )}
           </Link>
           <div className="flex items-center gap-3">
-            <UploadXLSX />
             <div className="relative" ref={notifRef}>
               <button
                 className="p-2 rounded-md text-white hover:text-white/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/30"

--- a/src/pages/SimulationClientsPage.tsx
+++ b/src/pages/SimulationClientsPage.tsx
@@ -1,18 +1,51 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import ListRow from '../components/ListRow';
 import EmptyState from '../components/EmptyState';
 import { useSimulationClientes } from '../hooks/useSimulationClientes';
+import UploadXLSX from '../components/UploadXLSX';
+import { Search } from 'lucide-react';
 
 export default function SimulationClientsPage() {
   const { clientes, loading, error, isUsingFallback } = useSimulationClientes();
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const filteredClientes = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+
+    if (!term) {
+      return clientes;
+    }
+
+    return clientes.filter((cliente) => cliente.nome.toLowerCase().includes(term));
+  }, [clientes, searchTerm]);
+
+  const showEmptyState = !loading && clientes.length === 0;
+  const showNoResults = !loading && clientes.length > 0 && filteredClientes.length === 0;
 
   return (
     <div className="space-y-4">
-      <div>
-        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Balanço Energético</h1>
-        <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
-          Selecione um cliente para visualizar custos atuais, estimativas e economia.
-        </p>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">Balanço Energético</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+            Encontre e acompanhe o saldo energético dos clientes.
+          </p>
+        </div>
+        <div className="sm:shrink-0">
+          <UploadXLSX />
+        </div>
+      </div>
+
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <input
+          type="search"
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+          placeholder="Buscar cliente por nome"
+          className="w-full rounded-lg border border-gray-200 bg-white py-2 pl-10 pr-3 text-sm text-gray-700 shadow-sm focus:border-yn-orange focus:outline-none focus:ring-1 focus:ring-yn-orange dark:border-[#2b3238] dark:bg-[#1a1f24] dark:text-gray-100"
+          aria-label="Buscar cliente por nome"
+        />
       </div>
 
       {error && !isUsingFallback && (
@@ -31,11 +64,13 @@ export default function SimulationClientsPage() {
       <div className="bg-white dark:bg-[#1a1f24] rounded-xl border border-gray-200 dark:border-[#2b3238] shadow-sm">
         {loading ? (
           <div className="p-6 text-sm text-gray-500 dark:text-gray-300">Carregando…</div>
-        ) : clientes.length === 0 ? (
+        ) : showEmptyState ? (
           <EmptyState message="Nenhum cliente retornado pelo BFF." />
+        ) : showNoResults ? (
+          <EmptyState message="Nenhum cliente encontrado com o nome informado." />
         ) : (
           <ul className="divide-y divide-gray-100 dark:divide-[#2b3238]">
-            {clientes.map((cliente) => (
+            {filteredClientes.map((cliente) => (
               <ListRow
                 key={cliente.id}
                 to={`/leads/simulation/${cliente.id}`}


### PR DESCRIPTION
## Summary
- update the sidebar and routing so "Balanço Energético" opens directly without legacy tabs
- move the invoice upload action into the energy balance view and add client name filtering with a search bar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd42dffa1883279e210b6dc77aa5b6