### PR TITLE
feat: fetch contracts from external API

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
-﻿VITE_API_BASE_URL=http://localhost:3000
+VITE_API_BASE_URL=http://localhost:3000
 VITE_API_MOCK=true
 VITE_PORTAL_MODE=gestao
+VITE_CONTRACTS_URL=https://657285488d18.ngrok-free.app/contracts

--- a/src/hooks/__tests__/useContracts.test.tsx
+++ b/src/hooks/__tests__/useContracts.test.tsx
@@ -1,0 +1,114 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useContracts } from '../useContracts';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var fetch: typeof globalThis.fetch;
+}
+
+const ORIGINAL_FETCH = global.fetch;
+
+const mockSuccessResponse = (body: unknown) =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(body),
+  } as Response);
+
+const mockErrorResponse = (status: number) =>
+  Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.resolve({}),
+  } as Response);
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe('useContracts', () => {
+  it('returns contracts from the API', async () => {
+    vi.stubEnv('VITE_CONTRACTS_URL', 'https://example.com/contracts');
+    const mockFetch = vi
+      .spyOn(global, 'fetch')
+      .mockImplementation(() =>
+        mockSuccessResponse([
+          {
+            id: 1,
+            client: 'Cliente testeNgrok',
+            contract: 987654321,
+            price: 123.56,
+            reference_base: '2024-10-01',
+            supplier: 'Fornecedor A',
+            contact_active: true,
+          },
+        ])
+      );
+
+    const { result } = renderHook(() => useContracts());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com/contracts',
+      expect.objectContaining({
+        method: 'GET',
+      })
+    );
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data[0]).toMatchObject({
+      customerName: 'Cliente testeNgrok',
+      contractNumber: '987654321',
+      status: 'ATIVO',
+      amount: 123.56,
+      supplier: 'Fornecedor A',
+      startDate: '2024-10-01',
+    });
+
+    mockFetch.mockResolvedValueOnce(
+      mockSuccessResponse({
+        data: [],
+      })
+    );
+
+    await result.current.refresh();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toHaveLength(0);
+  });
+
+  it('handles empty responses gracefully', async () => {
+    vi.stubEnv('VITE_CONTRACTS_URL', 'https://example.com/contracts');
+    vi.spyOn(global, 'fetch').mockImplementation(() =>
+      mockSuccessResponse({
+        data: [],
+      })
+    );
+
+    const { result } = renderHook(() => useContracts());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toHaveLength(0);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('captures API errors', async () => {
+    vi.stubEnv('VITE_CONTRACTS_URL', 'https://example.com/contracts');
+    vi.spyOn(global, 'fetch').mockImplementation(() => mockErrorResponse(500));
+
+    const { result } = renderHook(() => useContracts());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toHaveLength(0);
+    expect(result.current.error).toBeDefined();
+  });
+});

--- a/src/hooks/useContracts.ts
+++ b/src/hooks/useContracts.ts
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export type ContractStatus = 'ATIVO' | 'PENDENTE' | 'CANCELADO' | 'DESCONHECIDO';
+
+export type Contract = {
+  id: string;
+  contractNumber: string;
+  customerName: string;
+  status: ContractStatus;
+  amount: number | null;
+  startDate: string | null;
+  endDate: string | null;
+  supplier?: string | null;
+  monthlyConsumptionMWh?: number | null;
+  tags?: string[];
+};
+
+export type ContractsState = {
+  data: Contract[];
+  loading: boolean;
+  error?: string;
+  refresh: () => Promise<void>;
+};
+
+// Sample JSON for quick reference during development:
+// [
+//   {
+//     "id": "c-001",
+//     "contractNumber": "CTR-2025-0001",
+//     "customerName": "Empresa Alfa S/A",
+//     "supplier": "Neoenergia",
+//     "status": "ATIVO",
+//     "amount": 125000.45,
+//     "monthlyConsumptionMWh": 142.0,
+//     "startDate": "2025-01-01",
+//     "endDate": "2026-01-01"
+//   }
+// ]
+
+const KNOWN_FIELDS = new Set([
+  'id',
+  'contractNumber',
+  'customerName',
+  'client',
+  'contract',
+  'contract_id',
+  'status',
+  'contact_active',
+  'situation',
+  'amount',
+  'price',
+  'value',
+  'startDate',
+  'start_date',
+  'inicio',
+  'reference_base',
+  'endDate',
+  'end_date',
+  'fim',
+  'supplier',
+  'provider',
+  'utility',
+  'monthlyConsumptionMWh',
+  'consumption',
+  'monthly_consumption_mwh',
+  'meter',
+  'tags',
+  'labels',
+  'adjusted',
+  'createdAt',
+  'updatedAt',
+  'client_id',
+]);
+
+const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+});
+
+const dateFormatter = new Intl.DateTimeFormat('pt-BR', {
+  day: '2-digit',
+  month: '2-digit',
+  year: 'numeric',
+});
+
+function parseString(value: unknown): string {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length ? trimmed : '';
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return '';
+}
+
+function parseNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.replace(/\./g, '').replace(/,/g, '.');
+    const parsed = Number(normalized);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function parseDate(value: unknown): string | null {
+  const text = parseString(value);
+  if (!text) return null;
+  const isoMatch = text.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (isoMatch) {
+    return `${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}`;
+  }
+  const parsed = new Date(text);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toISOString().slice(0, 10);
+  }
+  return null;
+}
+
+function normalizeStatus(value: unknown, fallback?: unknown): ContractStatus {
+  const text = parseString(value).toUpperCase();
+  if (text === 'ATIVO' || text === 'ACTIVE') return 'ATIVO';
+  if (text === 'PENDENTE' || text === 'PENDING') return 'PENDENTE';
+  if (text === 'CANCELADO' || text === 'CANCELLED' || text === 'CANCELADA') return 'CANCELADO';
+  if (text) return 'DESCONHECIDO';
+
+  if (typeof fallback === 'boolean') {
+    return fallback ? 'ATIVO' : 'PENDENTE';
+  }
+
+  return 'DESCONHECIDO';
+}
+
+function extractTags(value: unknown, adjustedFlag: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const tags = value
+      .map((item) => parseString(item))
+      .filter((item): item is string => Boolean(item));
+    if (tags.length) {
+      return tags;
+    }
+  }
+  if (adjustedFlag === true) {
+    return ['Ajustado'];
+  }
+  return undefined;
+}
+
+function normalizeContract(raw: Record<string, unknown>): Contract {
+  if (import.meta.env.DEV) {
+    const unknownKeys = Object.keys(raw).filter((key) => !KNOWN_FIELDS.has(key));
+    if (unknownKeys.length) {
+      console.debug('[useContracts] Unknown fields received from API:', unknownKeys);
+    }
+  }
+
+  const idValue = raw.id ?? raw.contract_id ?? raw.contract ?? raw.contractNumber;
+  const id = parseString(idValue) || crypto.randomUUID();
+  const contractNumber = parseString(raw.contractNumber ?? raw.contract ?? id);
+  const customerName = parseString(raw.customerName ?? raw.client ?? 'Sem nome');
+  const status = normalizeStatus(raw.status, raw.contact_active);
+  const amount = parseNumber(raw.amount ?? raw.price ?? raw.value);
+  const startDate = parseDate(raw.startDate ?? raw.start_date ?? raw.inicio ?? raw.reference_base);
+  const endDate = parseDate(raw.endDate ?? raw.end_date ?? raw.fim);
+  const supplier = parseString(raw.supplier ?? raw.provider ?? raw.utility) || undefined;
+  const monthlyConsumptionMWh = parseNumber(
+    raw.monthlyConsumptionMWh ?? raw.monthly_consumption_mwh ?? raw.consumption
+  );
+  const tags = extractTags(raw.tags ?? raw.labels, raw.adjusted);
+
+  return {
+    id,
+    contractNumber: contractNumber || id,
+    customerName,
+    status,
+    amount,
+    startDate,
+    endDate,
+    supplier,
+    monthlyConsumptionMWh,
+    tags,
+  };
+}
+
+function ensureArray(data: unknown): unknown[] {
+  if (Array.isArray(data)) return data;
+  if (data && typeof data === 'object' && 'data' in data) {
+    const inner = (data as { data?: unknown }).data;
+    if (Array.isArray(inner)) return inner;
+  }
+  return [];
+}
+
+function buildUrl(): string {
+  const url = import.meta.env.VITE_CONTRACTS_URL ?? import.meta.env.VITE_CONTRACTS_API ?? '/contracts';
+  if (typeof url !== 'string' || !url.trim()) {
+    return '/contracts';
+  }
+  return url.trim();
+}
+
+async function fetchContracts(signal?: AbortSignal): Promise<Contract[]> {
+  const endpoint = buildUrl();
+  const response = await fetch(endpoint, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'ngrok-skip-browser-warning': 'true',
+    },
+    mode: endpoint.startsWith('http') ? 'cors' : 'same-origin',
+    credentials: 'omit',
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Erro ao buscar contratos (${response.status})`);
+  }
+
+  const json = await response.json();
+  const items = ensureArray(json);
+  return items
+    .map((item) => (item && typeof item === 'object' ? normalizeContract(item as Record<string, unknown>) : null))
+    .filter((item): item is Contract => Boolean(item));
+}
+
+export function formatCurrencyBRL(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return currencyFormatter.format(0).replace(/0,00$/, '--');
+  }
+  return currencyFormatter.format(value);
+}
+
+export function formatDateDDMMYYYY(value: string | null | undefined): string {
+  if (!value) return '--';
+  const parsed = parseDate(value);
+  if (!parsed) return '--';
+  const [year, month, day] = parsed.split('-').map((part) => Number(part));
+  const safeDate = new Date(Date.UTC(year, month - 1, day));
+  return dateFormatter.format(safeDate);
+}
+
+export function useContracts(): ContractsState {
+  const [data, setData] = useState<Contract[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | undefined>();
+  const abortRef = useRef<AbortController | null>(null);
+
+  const load = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setError(undefined);
+    try {
+      const contracts = await fetchContracts(controller.signal);
+      setData(contracts);
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      console.error('[useContracts] Failed to load contracts', err);
+      setError(err instanceof Error ? err.message : 'Erro desconhecido ao carregar contratos');
+      setData([]);
+    } finally {
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, [load]);
+
+  const refresh = useCallback(async () => {
+    await load();
+  }, [load]);
+
+  return useMemo(
+    () => ({
+      data,
+      loading,
+      error,
+      refresh,
+    }),
+    [data, loading, error, refresh]
+  );
+}

--- a/src/pages/contratos/ContractsContext.tsx
+++ b/src/pages/contratos/ContractsContext.tsx
@@ -1,588 +1,21 @@
 import React from 'react';
-import { ContractMock } from '../../mocks/contracts';
-import { mockContracts } from '../../mocks/contracts';
+import {
+  ContractMock,
+  mockContracts,
+} from '../../mocks/contracts';
+import {
+  Contract,
+  ContractStatus,
+  useContracts as useContractsApi,
+  formatCurrencyBRL,
+} from '../../hooks/useContracts';
 
-const DEFAULT_API_URL = 'https://657285488d18.ngrok-free.app';
-
-const resumoKeys: Array<keyof ContractMock['resumoConformidades']> = [
-  'Consumo',
-  'NF',
-  'Fatura',
-  'Encargos',
-  'Conformidade',
-];
-
-const statusResumoValues = ['Conforme', 'Divergente', 'Em análise'] as const;
-type StatusResumoValue = (typeof statusResumoValues)[number];
-
-const analiseStatusValues = ['verde', 'amarelo', 'vermelho'] as const;
-type AnaliseStatusValue = (typeof analiseStatusValues)[number];
-
-const invoiceStatusValues = ['Paga', 'Em aberto', 'Em análise'] as const;
-type InvoiceStatusValue = (typeof invoiceStatusValues)[number];
-
-const normalizeString = (value: unknown, fallback = '') => {
-  if (value === undefined || value === null) return fallback;
-  return String(value).trim();
+const statusMap: Record<ContractStatus, ContractMock['status']> = {
+  ATIVO: 'Ativo',
+  PENDENTE: 'Inativo',
+  CANCELADO: 'Inativo',
+  DESCONHECIDO: 'Ativo',
 };
-
-const normalizeIsoDate = (value: unknown): string => {
-  const text = normalizeString(value);
-  if (!text) return '';
-  const parsed = new Date(text);
-  if (!Number.isNaN(parsed.getTime())) {
-    return parsed.toISOString().slice(0, 10);
-  }
-  const isoMatch = text.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  return isoMatch ? text : '';
-};
-
-const normalizeReferenceMonth = (value: unknown): string => {
-  const isoDate = normalizeIsoDate(value);
-  if (isoDate) {
-    return isoDate.slice(0, 7);
-  }
-  const text = normalizeString(value);
-  const monthMatch = text.match(/^(\d{4})[-/](\d{2})/);
-  return monthMatch ? `${monthMatch[1]}-${monthMatch[2]}` : '';
-};
-
-const formatCurrencyBRL = (value: number): string => {
-  if (!Number.isFinite(value)) return 'R$ 0,00';
-  try {
-    return new Intl.NumberFormat('pt-BR', {
-      style: 'currency',
-      currency: 'BRL',
-      maximumFractionDigits: 2,
-    }).format(value);
-  } catch (error) {
-    console.warn('[ContractsContext] Falha ao formatar moeda, usando fallback.', error);
-    return `R$ ${value.toFixed(2)}`;
-  }
-};
-
-const removeDiacritics = (value: string) =>
-  value.normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase();
-
-const normalizeResumoStatus = (value: unknown): StatusResumoValue => {
-  const text = normalizeString(value).toLowerCase();
-  if (!text) return 'Em análise';
-  const sanitized = removeDiacritics(text);
-  if (sanitized === 'conforme') return 'Conforme';
-  if (sanitized === 'divergente') return 'Divergente';
-  if (sanitized.includes('analise')) return 'Em análise';
-  return 'Em análise';
-};
-
-const normalizeAnaliseStatus = (value: unknown): AnaliseStatusValue => {
-  const text = removeDiacritics(normalizeString(value));
-  if (analiseStatusValues.includes(text as AnaliseStatusValue)) {
-    return text as AnaliseStatusValue;
-  }
-  if (text === 'amarela') return 'amarelo';
-  if (text === 'vermelha') return 'vermelho';
-  return 'amarelo';
-};
-
-const normalizeInvoiceStatus = (value: unknown): InvoiceStatusValue => {
-  const text = removeDiacritics(normalizeString(value));
-  if (text === 'paga' || text === 'pagas') return 'Paga';
-  if (text === 'em aberto' || text === 'aberto') return 'Em aberto';
-  if (text.includes('analise')) return 'Em análise';
-  return 'Em análise';
-};
-
-const normalizeContratoStatus = (value: unknown): ContractMock['status'] => {
-  const text = removeDiacritics(normalizeString(value));
-  if (text === 'ativo' || text === 'ativos') return 'Ativo';
-  if (text === 'inativo' || text === 'inativos') return 'Inativo';
-  return 'Ativo';
-};
-
-const normalizeFonte = (value: unknown): ContractMock['fonte'] => {
-  const text = removeDiacritics(normalizeString(value));
-  if (text === 'incentivada' || text === 'incentivadao') return 'Incentivada';
-  return 'Convencional';
-};
-
-const normalizeResumo = (value: unknown): ContractMock['resumoConformidades'] => {
-  const resumo: ContractMock['resumoConformidades'] = {
-    Consumo: 'Em análise',
-    NF: 'Em análise',
-    Fatura: 'Em análise',
-    Encargos: 'Em análise',
-    Conformidade: 'Em análise',
-  };
-
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
-    Object.entries(value as Record<string, unknown>).forEach(([key, status]) => {
-      if (resumoKeys.includes(key as keyof ContractMock['resumoConformidades'])) {
-        resumo[key as keyof ContractMock['resumoConformidades']] = normalizeResumoStatus(status);
-      }
-    });
-  }
-
-  return resumo;
-};
-
-const normalizeContractData = (value: unknown): ContractMock['dadosContrato'] => {
-  if (!value) return [];
-  if (Array.isArray(value)) {
-    return value
-      .map((item) => ({
-        label: normalizeString((item as { label?: unknown }).label),
-        value: normalizeString((item as { value?: unknown }).value),
-      }))
-      .filter((item) => item.label || item.value);
-  }
-  if (typeof value === 'object') {
-    return Object.entries(value as Record<string, unknown>)
-      .map(([label, val]) => ({ label: normalizeString(label), value: normalizeString(val) }))
-      .filter((item) => item.label || item.value);
-  }
-  return [];
-};
-
-const normalizeKpis = (value: unknown): ContractMock['kpis'] => {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((item) => {
-      const label = normalizeString((item as { label?: unknown; nome?: unknown }).label ?? (item as { nome?: unknown }).nome);
-      const rawValue =
-        (item as { value?: unknown; valor?: unknown }).value ?? (item as { valor?: unknown }).valor;
-      const valueText = normalizeString(rawValue);
-      if (!label || !valueText) return null;
-      const helper = normalizeString((item as { helper?: unknown; descricao?: unknown }).helper ?? (item as { descricao?: unknown }).descricao);
-      const variationValue = normalizeString((item as { variation?: { value?: unknown } }).variation?.value ?? (item as { variacao?: unknown }).variacao);
-      const directionRaw = normalizeString((item as { variation?: { direction?: unknown } }).variation?.direction);
-      const directionText = removeDiacritics(directionRaw);
-      const direction: 'up' | 'down' | 'neutral' | undefined =
-        directionText === 'up' || directionText === 'positivo'
-          ? 'up'
-          : directionText === 'down' || directionText === 'negativo'
-          ? 'down'
-          : directionText
-          ? 'neutral'
-          : undefined;
-
-      return {
-        label,
-        value: valueText,
-        helper: helper || undefined,
-        variation:
-          variationValue && direction
-            ? {
-                value: variationValue,
-                direction,
-              }
-            : undefined,
-      };
-    })
-    .filter((item): item is ContractMock['kpis'][number] => Boolean(item));
-};
-
-const normalizeHistoricoDemanda = (value: unknown): ContractMock['historicoDemanda'] => {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((item) => ({
-      mes: normalizeString((item as { mes?: unknown; competencia?: unknown }).mes ?? (item as { competencia?: unknown }).competencia),
-      ponta: Number((item as { ponta?: unknown; pontaMWh?: unknown }).ponta ?? (item as { pontaMWh?: unknown }).pontaMWh) || 0,
-      foraPonta:
-        Number((item as { foraPonta?: unknown; fora_ponta?: unknown }).foraPonta ?? (item as { fora_ponta?: unknown }).fora_ponta) || 0,
-    }))
-    .filter((item) => item.mes);
-};
-
-const normalizeHistoricoConsumo = (value: unknown): ContractMock['historicoConsumo'] => {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((item) => ({
-      mes: normalizeString((item as { mes?: unknown; competencia?: unknown }).mes ?? (item as { competencia?: unknown }).competencia),
-      meta: Number((item as { meta?: unknown }).meta) || 0,
-      realizado: Number((item as { realizado?: unknown }).realizado) || 0,
-    }))
-    .filter((item) => item.mes);
-};
-
-const normalizeObrigacoes = (value: unknown): ContractMock['obrigacoes'] => {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((item) => {
-      const periodo = normalizeString((item as { periodo?: unknown }).periodo);
-      if (!periodo) return null;
-      const statusObj: Record<string, ContractMock['resumoConformidades'][keyof ContractMock['resumoConformidades']]> = {};
-      const statusRaw = (item as { status?: unknown; etapas?: unknown }).status ?? (item as { etapas?: unknown }).etapas;
-      if (statusRaw && typeof statusRaw === 'object') {
-        Object.entries(statusRaw as Record<string, unknown>).forEach(([key, status]) => {
-          statusObj[key] = normalizeResumoStatus(status);
-        });
-      }
-      return {
-        periodo,
-        status: statusObj,
-      };
-    })
-    .filter((item): item is ContractMock['obrigacoes'][number] => Boolean(item));
-};
-
-const etapaNomeValues = ['Dados', 'Cálculo', 'Análise'] as const;
-type EtapaNomeValue = (typeof etapaNomeValues)[number];
-
-const normalizeEtapaNome = (value: unknown): EtapaNomeValue => {
-  const text = normalizeString(value);
-  if (!text) return 'Dados';
-  const sanitized = removeDiacritics(text);
-  const match = etapaNomeValues.find((option) => removeDiacritics(option) === sanitized);
-  if (match) return match;
-  if (sanitized.includes('calc')) return 'Cálculo';
-  if (sanitized.includes('anal')) return 'Análise';
-  return 'Dados';
-};
-
-const normalizeAnalises = (value: unknown): ContractMock['analises'] => {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((item) => {
-      const area = normalizeString((item as { area?: unknown; nome?: unknown }).area ?? (item as { nome?: unknown }).nome);
-      if (!area) return null;
-      const etapasRaw = (item as { etapas?: unknown; steps?: unknown }).etapas ?? (item as { steps?: unknown }).steps;
-      const etapas = Array.isArray(etapasRaw)
-        ? etapasRaw
-            .map((etapa) => ({
-              nome: normalizeEtapaNome((etapa as { nome?: unknown; etapa?: unknown }).nome ?? (etapa as { etapa?: unknown }).etapa),
-              status: normalizeAnaliseStatus((etapa as { status?: unknown }).status),
-              observacao: normalizeString((etapa as { observacao?: unknown; descricao?: unknown }).observacao ?? (etapa as { descricao?: unknown }).descricao) || undefined,
-            }))
-            .filter((etapa) => analiseStatusValues.includes(etapa.status))
-        : [];
-      return {
-        area,
-        etapas,
-      };
-    })
-    .filter((item): item is ContractMock['analises'][number] => Boolean(item));
-};
-
-const normalizeFaturas = (value: unknown): ContractMock['faturas'] => {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((item, index) => {
-      const rawId =
-        (item as { id?: unknown }).id ??
-        (item as { identificador?: unknown }).identificador ??
-        `invoice-${index + 1}`;
-      const rawArquivo = (item as { arquivo?: unknown }).arquivo ?? (item as { url?: unknown }).url;
-      return {
-        id: normalizeString(rawId),
-        competencia: normalizeString((item as { competencia?: unknown }).competencia),
-        vencimento: normalizeString((item as { vencimento?: unknown; dueDate?: unknown }).vencimento ?? (item as { dueDate?: unknown }).dueDate),
-        valor: Number((item as { valor?: unknown }).valor) || 0,
-        status: normalizeInvoiceStatus((item as { status?: unknown }).status),
-        arquivo: rawArquivo ? normalizeString(rawArquivo) : undefined,
-      };
-    })
-    .filter((item) => item.competencia);
-};
-
-const normalizePeriodos = (value: unknown): ContractMock['periodos'] => {
-  if (!Array.isArray(value)) return [];
-  return value.map((periodo) => normalizeString(periodo)).filter(Boolean);
-};
-
-const normalizeContractsFromApi = (payload: unknown): ContractMock[] => {
-  const extractArray = (data: unknown): unknown[] => {
-    if (Array.isArray(data)) return data;
-    if (!data || typeof data !== 'object') return [];
-    const maybeArrayKeys = ['contratos', 'contracts', 'items', 'data', 'result'];
-    for (const key of maybeArrayKeys) {
-      const value = (data as Record<string, unknown>)[key];
-      if (Array.isArray(value)) return value;
-      if (value && typeof value === 'object' && Array.isArray((value as Record<string, unknown>).items)) {
-        return (value as Record<string, unknown>).items as unknown[];
-      }
-      if (value && typeof value === 'object' && Array.isArray((value as Record<string, unknown>).contratos)) {
-        return (value as Record<string, unknown>).contratos as unknown[];
-      }
-    }
-    return [];
-  };
-
-  const rawContracts = extractArray(payload);
-  return rawContracts.map((item, index) => {
-    const baseId = normalizeString((item as { id?: unknown; codigo?: unknown }).id ?? (item as { codigo?: unknown }).codigo);
-    const id = baseId || `contract-${index + 1}`;
-
-    const referenceBaseRaw =
-      (item as { reference_base?: unknown }).reference_base ??
-      (item as { referenciaBase?: unknown }).referenciaBase ??
-      (item as { baseReferencia?: unknown }).baseReferencia;
-
-    const referenceMonth = normalizeReferenceMonth(referenceBaseRaw);
-    const ciclo =
-      normalizeString(
-        (item as { cicloFaturamento?: unknown; ciclo?: unknown; periodo?: unknown }).cicloFaturamento ??
-          (item as { ciclo?: unknown }).ciclo ??
-          (item as { periodo?: unknown }).periodo ??
-          referenceMonth
-      ) || referenceMonth;
-
-    const rawCodigo =
-      (item as { codigo?: unknown }).codigo ??
-      (item as { codigoContrato?: unknown }).codigoContrato ??
-      (item as { contract?: unknown }).contract ??
-      id;
-    const rawCliente =
-      (item as { cliente?: unknown }).cliente ??
-      (item as { client?: unknown }).client ??
-      (item as { nomeCliente?: unknown }).nomeCliente ??
-      'Cliente não informado';
-    const rawSegmento = (item as { segmento?: unknown }).segmento ?? 'Não informado';
-    const rawContato =
-      (item as { contato?: unknown }).contato ??
-      (item as { responsavel?: unknown }).responsavel ??
-      (item as { contact?: unknown }).contact ??
-      '';
-
-    const contatoAtivoRaw =
-      (item as { contact_active?: unknown }).contact_active ??
-      (item as { contatoAtivo?: unknown }).contatoAtivo ??
-      (item as { ativoContato?: unknown }).ativoContato;
-
-    const contatoAtivo =
-      typeof contatoAtivoRaw === 'boolean'
-        ? contatoAtivoRaw
-        : typeof contatoAtivoRaw === 'string'
-        ? contatoAtivoRaw.toLowerCase() === 'true'
-        : undefined;
-
-    const supplier =
-      normalizeString((item as { supplier?: unknown }).supplier ?? (item as { fornecedor?: unknown }).fornecedor) ||
-      'Não informado';
-    const meter = normalizeString((item as { meter?: unknown }).meter ?? (item as { medidor?: unknown }).medidor);
-    const clientId = normalizeString(
-      (item as { client_id?: unknown }).client_id ?? (item as { clienteId?: unknown }).clienteId
-    );
-
-    const rawPrice =
-      (item as { price?: unknown }).price ??
-      (item as { preco?: unknown }).preco ??
-      (item as { precoMedio?: unknown }).precoMedio;
-    const precoMedio = Number(rawPrice) || 0;
-    const precoSpotReferencia =
-      Number(
-        (item as { precoSpotReferencia?: unknown; precoSpot?: unknown }).precoSpotReferencia ??
-          (item as { precoSpot?: unknown }).precoSpot
-      ) || 0;
-
-    const inicioVigencia = normalizeIsoDate(
-      (item as { inicioVigencia?: unknown; vigenciaInicio?: unknown }).inicioVigencia ??
-        (item as { vigenciaInicio?: unknown }).vigenciaInicio ??
-        referenceBaseRaw
-    );
-    const fimVigencia = normalizeIsoDate(
-      (item as { fimVigencia?: unknown; vigenciaFim?: unknown }).fimVigencia ??
-        (item as { vigenciaFim?: unknown }).vigenciaFim
-    );
-
-    const periodosBase = normalizePeriodos(
-      (item as { periodos?: unknown }).periodos ??
-        (item as { meses?: unknown }).meses ??
-        (item as { ciclos?: unknown }).ciclos
-    );
-    const periodos = referenceMonth
-      ? Array.from(new Set([...periodosBase, referenceMonth]))
-      : periodosBase;
-
-    const resumo = normalizeResumo(
-      (item as { resumoConformidades?: unknown; conformidades?: unknown }).resumoConformidades ??
-        (item as { conformidades?: unknown }).conformidades
-    );
-
-    const adjustedRaw =
-      (item as { adjusted?: unknown }).adjusted ?? (item as { ajustado?: unknown }).ajustado;
-    const adjusted =
-      typeof adjustedRaw === 'boolean'
-        ? adjustedRaw
-        : typeof adjustedRaw === 'string'
-        ? adjustedRaw.toLowerCase() === 'true'
-        : undefined;
-
-    if (adjusted !== undefined) {
-      const resumoStatus: ContractMock['resumoConformidades']['Consumo'] = adjusted ? 'Conforme' : 'Em análise';
-      resumo.Consumo = resumoStatus;
-      resumo.Fatura = resumoStatus;
-      resumo.Conformidade = resumoStatus;
-    }
-
-    const dadosContratoBase: ContractMock['dadosContrato'] = [
-      ...normalizeContractData(
-        (item as { dadosContrato?: unknown; dados?: unknown }).dadosContrato ??
-          (item as { dados?: unknown }).dados
-      ),
-    ];
-
-    const dadosContratoKeys = new Set(dadosContratoBase.map((field) => removeDiacritics(field.label)));
-    const ensureField = (label: string, value: string) => {
-      const normalizedLabel = removeDiacritics(label);
-      const finalValue = normalizeString(value);
-      if (!finalValue) return;
-      if (!dadosContratoKeys.has(normalizedLabel)) {
-        dadosContratoKeys.add(normalizedLabel);
-        dadosContratoBase.push({ label, value: finalValue });
-      }
-    };
-
-    ensureField('Fornecedor', supplier);
-    ensureField('Medidor', meter || 'Não informado');
-    ensureField('Preço (R$/MWh)', precoMedio ? formatCurrencyBRL(precoMedio) : 'Não informado');
-    ensureField('Contrato', normalizeString(rawCodigo));
-    ensureField('Cliente ID', clientId || 'Não informado');
-    if (adjusted !== undefined) {
-      ensureField('Ajustado', adjusted ? 'Sim' : 'Não');
-    }
-    if (referenceBaseRaw) {
-      ensureField('Base de referência', normalizeIsoDate(referenceBaseRaw) || normalizeString(referenceBaseRaw));
-    }
-
-    const kpisBase: ContractMock['kpis'] = [
-      ...normalizeKpis((item as { kpis?: unknown; indicadores?: unknown }).kpis ?? (item as { indicadores?: unknown }).indicadores),
-    ];
-    if (precoMedio) {
-      kpisBase.push({ label: 'Preço contratado', value: formatCurrencyBRL(precoMedio) });
-    }
-    if (typeof contatoAtivo === 'boolean') {
-      kpisBase.push({ label: 'Contato', value: contatoAtivo ? 'Ativo' : 'Inativo' });
-    }
-
-    const contatoFinal =
-      normalizeString(rawContato) ||
-      (typeof contatoAtivo === 'boolean' ? (contatoAtivo ? 'Contato ativo' : 'Contato inativo') : 'Não informado');
-
-    const statusValor =
-      typeof contatoAtivo === 'boolean'
-        ? contatoAtivo
-          ? 'Ativo'
-          : 'Inativo'
-        : normalizeContratoStatus((item as { status?: unknown }).status);
-
-    return {
-      id,
-      codigo: normalizeString(rawCodigo),
-      cliente: normalizeString(rawCliente),
-      cnpj: normalizeString((item as { cnpj?: unknown }).cnpj),
-      segmento: normalizeString(rawSegmento),
-      contato: contatoFinal,
-      status: statusValor,
-      fonte: normalizeFonte((item as { fonte?: unknown }).fonte),
-      modalidade: normalizeString((item as { modalidade?: unknown }).modalidade || 'Não informado'),
-      inicioVigencia: inicioVigencia || normalizeString((item as { inicio?: unknown }).inicio),
-      fimVigencia: fimVigencia,
-      limiteSuperior: normalizeString((item as { limiteSuperior?: unknown }).limiteSuperior),
-      limiteInferior: normalizeString((item as { limiteInferior?: unknown }).limiteInferior),
-      flex: normalizeString((item as { flex?: unknown; flexibilidade?: unknown }).flex ?? (item as { flexibilidade?: unknown }).flexibilidade),
-      precoMedio,
-      precoSpotReferencia,
-      cicloFaturamento: ciclo,
-      periodos,
-      resumoConformidades: resumo,
-      kpis: kpisBase,
-      dadosContrato: dadosContratoBase,
-      historicoDemanda: normalizeHistoricoDemanda((item as { historicoDemanda?: unknown; demanda?: unknown }).historicoDemanda ?? (item as { demanda?: unknown }).demanda),
-      historicoConsumo: normalizeHistoricoConsumo((item as { historicoConsumo?: unknown; consumo?: unknown }).historicoConsumo ?? (item as { consumo?: unknown }).consumo),
-      obrigacoes: normalizeObrigacoes((item as { obrigacoes?: unknown }).obrigacoes),
-      analises: normalizeAnalises((item as { analises?: unknown; analisesConformidade?: unknown }).analises ?? (item as { analisesConformidade?: unknown }).analisesConformidade),
-      faturas: normalizeFaturas((item as { faturas?: unknown; invoices?: unknown }).faturas ?? (item as { invoices?: unknown }).invoices),
-    } satisfies ContractMock;
-  });
-};
-
-const buildEndpointCandidates = (rawUrl: string): string[] => {
-  const normalized = normalizeString(rawUrl) || DEFAULT_API_URL;
-  const sanitized = normalized.replace(/\s/g, '');
-  if (!sanitized) return [DEFAULT_API_URL];
-  const withoutTrailingSlash = sanitized.replace(/\/$/, '');
-  const candidates = new Set<string>();
-  candidates.add(withoutTrailingSlash);
-  if (!/\/(contratos|contracts)(\b|\d|\/)/i.test(withoutTrailingSlash)) {
-    candidates.add(`${withoutTrailingSlash}/contratos`);
-  }
-  return Array.from(candidates);
-};
-
-type FetchAttemptConfig = {
-  method: 'GET' | 'POST';
-  body?: string;
-};
-
-async function fetchContracts(signal?: AbortSignal): Promise<ContractMock[]> {
-  const rawUrl = normalizeString(import.meta.env.VITE_CONTRACTS_API_URL);
-  const endpoints = buildEndpointCandidates(rawUrl);
-  let lastError: unknown;
-
-  for (const endpoint of endpoints) {
-    const attempts: FetchAttemptConfig[] = [
-      { method: 'GET' },
-      { method: 'POST', body: '{}' },
-    ];
-
-    for (const attempt of attempts) {
-      try {
-        console.info(
-          `[ContractsContext] Buscando contratos da API em ${endpoint} usando ${attempt.method}.`
-        );
-        const response = await fetch(endpoint, {
-          method: attempt.method,
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-            'ngrok-skip-browser-warning': 'true',
-          },
-          mode: 'cors',
-          credentials: 'omit',
-          body: attempt.body ?? undefined,
-          signal,
-        });
-
-        if (!response.ok) {
-          throw new Error(`Erro ao buscar contratos (${response.status})`);
-        }
-
-        const data = await response.json();
-        const contracts = normalizeContractsFromApi(data);
-        if (!contracts.length) {
-          console.warn('[ContractsContext] API retornou lista vazia de contratos.');
-        }
-        console.info(
-          `[ContractsContext] Contratos carregados com sucesso: ${contracts.length} itens recebidos.`
-        );
-        return contracts;
-      } catch (error) {
-        if (signal?.aborted) {
-          throw error;
-        }
-        lastError = error;
-        console.error(
-          `[ContractsContext] Erro ao buscar contratos em ${endpoint} com método ${attempt.method}.`,
-          error instanceof Error ? error : new Error(String(error))
-        );
-        if (error instanceof TypeError && error.message === 'Failed to fetch') {
-          console.error(
-            '[ContractsContext] Falha de rede ao buscar contratos. Possível problema de CORS ou indisponibilidade da API.'
-          );
-        }
-        if (attempt.method === 'POST') {
-          console.info('[ContractsContext] Tentando próximo endpoint disponível...');
-        } else {
-          console.info('[ContractsContext] Tentando novamente usando POST como fallback...');
-        }
-      }
-    }
-  }
-
-  throw (lastError instanceof Error
-    ? lastError
-    : new Error('Erro desconhecido ao carregar contratos'));
-}
 
 export type ContractUpdater = (contract: ContractMock) => ContractMock;
 
@@ -598,6 +31,143 @@ type ContractsContextValue = {
 
 const ContractsContext = React.createContext<ContractsContextValue | undefined>(undefined);
 
+function cloneContract(contract: ContractMock): ContractMock {
+  return JSON.parse(JSON.stringify(contract)) as ContractMock;
+}
+
+function toIsoDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString().slice(0, 10);
+}
+
+function monthFromDate(value: string | null | undefined): string | null {
+  const iso = toIsoDate(value);
+  return iso ? iso.slice(0, 7) : null;
+}
+
+function buildPeriods(start: string | null, end: string | null, fallback: string[]): string[] {
+  const startMonth = monthFromDate(start);
+  const endMonth = monthFromDate(end);
+  if (!startMonth && !endMonth) {
+    return fallback;
+  }
+  if (startMonth && !endMonth) {
+    return [startMonth];
+  }
+  if (!startMonth || !endMonth) {
+    return fallback;
+  }
+
+  const result: string[] = [];
+  const current = new Date(`${startMonth}-01T00:00:00Z`);
+  const limit = new Date(`${endMonth}-01T00:00:00Z`);
+  if (Number.isNaN(current.getTime()) || Number.isNaN(limit.getTime())) {
+    return fallback;
+  }
+
+  while (current <= limit) {
+    const year = current.getUTCFullYear();
+    const month = String(current.getUTCMonth() + 1).padStart(2, '0');
+    result.push(`${year}-${month}`);
+    current.setUTCMonth(current.getUTCMonth() + 1);
+  }
+
+  return result.sort((a, b) => (a < b ? 1 : -1));
+}
+
+function buildVigenciaLabel(start: string | null, end: string | null, fallback: string): string {
+  const startIso = toIsoDate(start);
+  const endIso = toIsoDate(end);
+  if (!startIso && !endIso) return fallback;
+
+  const formatMonthYear = (iso: string | null) => {
+    if (!iso) return null;
+    const [year, month, day] = iso.split('-').map((part) => Number(part));
+    const date = new Date(Date.UTC(year, month - 1, day));
+    return new Intl.DateTimeFormat('pt-BR', {
+      month: 'short',
+      year: 'numeric',
+    })
+      .format(date)
+      .replace('.', '');
+  };
+
+  const startLabel = formatMonthYear(startIso);
+  const endLabel = formatMonthYear(endIso);
+  if (startLabel && endLabel) {
+    return `${startLabel} - ${endLabel}`;
+  }
+  return startLabel ?? endLabel ?? fallback;
+}
+
+function formatMonthlyConsumption(value: number | null | undefined, fallback: string): string {
+  if (value === null || value === undefined) return fallback;
+  return `${new Intl.NumberFormat('pt-BR', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value)} MWh/mês`;
+}
+
+function mapContractToMock(contract: Contract, index: number): ContractMock {
+  const template = cloneContract(mockContracts[index % mockContracts.length]);
+  const startDate = toIsoDate(contract.startDate);
+  const endDate = toIsoDate(contract.endDate);
+  const ciclo = monthFromDate(contract.startDate) ?? template.cicloFaturamento;
+
+  return {
+    ...template,
+    id: contract.id,
+    codigo: contract.contractNumber || template.codigo,
+    cliente: contract.customerName || template.cliente,
+    status: statusMap[contract.status] ?? template.status,
+    precoMedio: contract.amount ?? template.precoMedio,
+    cicloFaturamento: ciclo,
+    inicioVigencia: startDate ?? template.inicioVigencia,
+    fimVigencia: endDate ?? template.fimVigencia,
+    periodos: buildPeriods(startDate, endDate, template.periodos),
+    dadosContrato: template.dadosContrato.map((field) => {
+      const label = field.label.toLowerCase();
+      if (label.includes('fornecedor')) {
+        return {
+          ...field,
+          value: contract.supplier ?? field.value,
+        };
+      }
+      if (label.includes('vigência')) {
+        return {
+          ...field,
+          value: buildVigenciaLabel(startDate, endDate, field.value),
+        };
+      }
+      if (label.includes('volume') && contract.monthlyConsumptionMWh !== undefined) {
+        return {
+          ...field,
+          value: formatMonthlyConsumption(contract.monthlyConsumptionMWh, field.value),
+        };
+      }
+      if (label.includes('preço médio') && contract.amount !== null && contract.amount !== undefined) {
+        return {
+          ...field,
+          value: formatCurrencyBRL(contract.amount),
+        };
+      }
+      return field;
+    }),
+    kpis: template.kpis.map((item, kpiIndex) => {
+      if (kpiIndex === 0 && contract.amount !== null && contract.amount !== undefined) {
+        return {
+          ...item,
+          value: formatCurrencyBRL(contract.amount),
+          helper: contract.supplier ? `Fornecedor: ${contract.supplier}` : item.helper,
+        };
+      }
+      return item;
+    }),
+  };
+}
+
 function applyUpdate(contract: ContractMock, update: ContractUpdater | Partial<ContractMock>): ContractMock {
   if (typeof update === 'function') {
     return update(contract);
@@ -608,56 +178,24 @@ function applyUpdate(contract: ContractMock, update: ContractUpdater | Partial<C
   };
 }
 
-function cloneContract(contract: ContractMock): ContractMock {
-  return JSON.parse(JSON.stringify(contract)) as ContractMock;
-}
-
 export function ContractsProvider({ children }: { children: React.ReactNode }) {
-  const [contracts, setContracts] = React.useState<ContractMock[]>([]);
-  const [isLoading, setIsLoading] = React.useState<boolean>(true);
-  const [error, setError] = React.useState<string | null>(null);
-
-  const loadContracts = React.useCallback(
-    async (signal?: AbortSignal) => {
-      setIsLoading(true);
-      try {
-        const apiContracts = await fetchContracts(signal);
-        if (signal?.aborted) return;
-        setContracts(apiContracts.map((contract) => cloneContract(contract)));
-        setError(null);
-      } catch (err) {
-        if (signal?.aborted) return;
-        console.error('[ContractsProvider] Falha ao buscar contratos da API, utilizando mocks.', err);
-        setError(err instanceof Error ? err.message : 'Erro desconhecido ao carregar contratos');
-        setContracts(mockContracts.map((contract) => cloneContract(contract)));
-      } finally {
-        if (!signal?.aborted) {
-          setIsLoading(false);
-        }
-      }
-    },
-    []
-  );
+  const { data: apiContracts, loading, error, refresh } = useContractsApi();
+  const [manualContracts, setManualContracts] = React.useState<ContractMock[]>([]);
+  const [remoteContracts, setRemoteContracts] = React.useState<ContractMock[]>([]);
 
   React.useEffect(() => {
-    const controller = new AbortController();
-    loadContracts(controller.signal);
-    return () => controller.abort();
-  }, [loadContracts]);
+    setRemoteContracts(apiContracts.map((contract, index) => mapContractToMock(contract, index)));
+  }, [apiContracts]);
 
-  const refreshContracts = React.useCallback(async () => {
-    await loadContracts();
-  }, [loadContracts]);
-
-  const addContract = React.useCallback((contract: ContractMock) => {
-    setContracts((prev) => [cloneContract(contract), ...prev]);
-  }, []);
+  const contracts = React.useMemo(
+    () => [...manualContracts, ...remoteContracts],
+    [manualContracts, remoteContracts]
+  );
 
   const updateContract = React.useCallback(
     (id: string, updater: ContractUpdater | Partial<ContractMock>) => {
-      setContracts((prev) =>
-        prev.map((contract) => (contract.id === id ? applyUpdate(contract, updater) : contract))
-      );
+      setManualContracts((prev) => prev.map((contract) => (contract.id === id ? applyUpdate(contract, updater) : contract)));
+      setRemoteContracts((prev) => prev.map((contract) => (contract.id === id ? applyUpdate(contract, updater) : contract)));
     },
     []
   );
@@ -667,20 +205,28 @@ export function ContractsProvider({ children }: { children: React.ReactNode }) {
     [contracts]
   );
 
-  const value = React.useMemo(
+  const addContract = React.useCallback((contract: ContractMock) => {
+    setManualContracts((prev) => [cloneContract(contract), ...prev]);
+  }, []);
+
+  const refreshContracts = React.useCallback(async () => {
+    await refresh();
+  }, [refresh]);
+
+  const contextValue = React.useMemo(
     () => ({
       contracts,
-      isLoading,
-      error,
+      isLoading: loading,
+      error: error ?? null,
       updateContract,
       getContractById,
       addContract,
       refreshContracts,
     }),
-    [contracts, isLoading, error, updateContract, getContractById, addContract, refreshContracts]
+    [contracts, loading, error, updateContract, getContractById, addContract, refreshContracts]
   );
 
-  return <ContractsContext.Provider value={value}>{children}</ContractsContext.Provider>;
+  return <ContractsContext.Provider value={contextValue}>{children}</ContractsContext.Provider>;
 }
 
 export function useContracts() {

--- a/src/pages/contratos/__tests__/ContratosPage.test.tsx
+++ b/src/pages/contratos/__tests__/ContratosPage.test.tsx
@@ -1,16 +1,50 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, within, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ContratosPage from '..';
+import { ContractsProvider } from '../ContractsContext';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../../../hooks/useContracts', async () => {
+  const actual = await vi.importActual<typeof import('../../../hooks/useContracts')>(
+    '../../../hooks/useContracts'
+  );
+  const { mockContracts } = await vi.importActual<typeof import('../../../mocks/contracts')>(
+    '../../../mocks/contracts'
+  );
+
+  return {
+    ...actual,
+    useContracts: () => ({
+      data: mockContracts.slice(0, 10).map((contract) => ({
+        id: contract.id,
+        contractNumber: contract.codigo,
+        customerName: contract.cliente,
+        status: contract.status === 'Ativo' ? 'ATIVO' : 'PENDENTE',
+        amount: contract.precoMedio,
+        startDate: contract.inicioVigencia,
+        endDate: contract.fimVigencia,
+        supplier: contract.dadosContrato.find((field) => field.label === 'Fornecedor')?.value,
+        monthlyConsumptionMWh: 120,
+        tags: undefined,
+      })),
+      loading: false,
+      error: undefined,
+      refresh: vi.fn(),
+    }),
+    formatCurrencyBRL: actual.formatCurrencyBRL,
+  };
+});
 
 function renderWithProviders(ui: React.ReactElement) {
   const qc = new QueryClient();
   return render(
     <MemoryRouter>
-      <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+      <QueryClientProvider client={qc}>
+        <ContractsProvider>{ui}</ContractsProvider>
+      </QueryClientProvider>
     </MemoryRouter>
   );
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,22 @@
-import '@testing-library/jest-dom';
 import { afterAll, afterEach, beforeAll } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+class TestResizeObserver {
+  callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (typeof window !== 'undefined' && typeof window.ResizeObserver === 'undefined') {
+  // @ts-expect-error - provide minimal stub for jsdom
+  window.ResizeObserver = TestResizeObserver;
+}
 import { server } from './msw';
 
 beforeAll(() => server.listen());


### PR DESCRIPTION
## Summary
- add a reusable `useContracts` hook that normalizes responses from the live contracts endpoint and exposes formatting helpers
- refactor the contratos context to hydrate UI data from the hook while keeping manual contract mutations intact
- update the contratos page test harness and shared test setup to support the new hook and add dedicated hook tests

## Testing
- npm test -- --run src/hooks/__tests__/useContracts.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e2e2408fd083279970a2059108be75