### PR TITLE
Fetch contracts using a simple GET request

### DIFF
--- a/src/pages/contratos/ContractsContext.tsx
+++ b/src/pages/contratos/ContractsContext.tsx
@@ -509,73 +509,52 @@ const buildEndpointCandidates = (rawUrl: string): string[] => {
   return Array.from(candidates);
 };
 
-type FetchAttemptConfig = {
-  method: 'GET' | 'POST';
-  body?: string;
-};
-
 async function fetchContracts(signal?: AbortSignal): Promise<ContractMock[]> {
   const rawUrl = normalizeString(import.meta.env.VITE_CONTRACTS_API_URL);
   const endpoints = buildEndpointCandidates(rawUrl);
   let lastError: unknown;
 
   for (const endpoint of endpoints) {
-    const attempts: FetchAttemptConfig[] = [
-      { method: 'GET' },
-      { method: 'POST', body: '{}' },
-    ];
+    try {
+      console.info(`[ContractsContext] Buscando contratos da API em ${endpoint} usando GET.`);
+      const response = await fetch(endpoint, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+        },
+        mode: 'cors',
+        credentials: 'omit',
+        signal,
+      });
 
-    for (const attempt of attempts) {
-      try {
-        console.info(
-          `[ContractsContext] Buscando contratos da API em ${endpoint} usando ${attempt.method}.`
-        );
-        const response = await fetch(endpoint, {
-          method: attempt.method,
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-            'ngrok-skip-browser-warning': 'true',
-          },
-          mode: 'cors',
-          credentials: 'omit',
-          body: attempt.body ?? undefined,
-          signal,
-        });
-
-        if (!response.ok) {
-          throw new Error(`Erro ao buscar contratos (${response.status})`);
-        }
-
-        const data = await response.json();
-        const contracts = normalizeContractsFromApi(data);
-        if (!contracts.length) {
-          console.warn('[ContractsContext] API retornou lista vazia de contratos.');
-        }
-        console.info(
-          `[ContractsContext] Contratos carregados com sucesso: ${contracts.length} itens recebidos.`
-        );
-        return contracts;
-      } catch (error) {
-        if (signal?.aborted) {
-          throw error;
-        }
-        lastError = error;
-        console.error(
-          `[ContractsContext] Erro ao buscar contratos em ${endpoint} com método ${attempt.method}.`,
-          error instanceof Error ? error : new Error(String(error))
-        );
-        if (error instanceof TypeError && error.message === 'Failed to fetch') {
-          console.error(
-            '[ContractsContext] Falha de rede ao buscar contratos. Possível problema de CORS ou indisponibilidade da API.'
-          );
-        }
-        if (attempt.method === 'POST') {
-          console.info('[ContractsContext] Tentando próximo endpoint disponível...');
-        } else {
-          console.info('[ContractsContext] Tentando novamente usando POST como fallback...');
-        }
+      if (!response.ok) {
+        throw new Error(`Erro ao buscar contratos (${response.status})`);
       }
+
+      const data = await response.json();
+      const contracts = normalizeContractsFromApi(data);
+      if (!contracts.length) {
+        console.warn('[ContractsContext] API retornou lista vazia de contratos.');
+      }
+      console.info(
+        `[ContractsContext] Contratos carregados com sucesso: ${contracts.length} itens recebidos.`
+      );
+      return contracts;
+    } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
+      lastError = error;
+      console.error(
+        `[ContractsContext] Erro ao buscar contratos em ${endpoint}.`,
+        error instanceof Error ? error : new Error(String(error))
+      );
+      if (error instanceof TypeError && error.message === 'Failed to fetch') {
+        console.error(
+          '[ContractsContext] Falha de rede ao buscar contratos. Possível problema de CORS ou indisponibilidade da API.'
+        );
+      }
+      console.info('[ContractsContext] Tentando próximo endpoint disponível...');
     }
   }
 


### PR DESCRIPTION
## Summary
- remove the ngrok query helper and related headers so the configured URL is requested as-is
- load contracts exclusively with a GET call and parse the returned JSON payload

## Testing
- npm test (fails: ReferenceError: expect is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68e2ed634ca48327b2d242428f7c78ba