### PR TITLE
Add energy balance card with backend data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,8 +58,8 @@ function AppRoutes() {
             </Route>
 
             {/* Conteúdo legado do portal de consultores (pode ser ajustado por role no futuro) */}
-            <Route path="leads" element={<SimulationClientsPage />} />
-            <Route path="leads/:clientId" element={<SimulationClientPage />} />
+            <Route path="leads/simulation" element={<SimulationClientsPage />} />
+            <Route path="leads/simulation/:clientId" element={<SimulationClientPage />} />
             <Route path="agenda" element={<AgendaPage />} />
             <Route path="commissions" element={<CommissionsPage />} />
             <Route path="profile" element={<ProfilePage />} />

--- a/src/components/EnergyBalanceCard.tsx
+++ b/src/components/EnergyBalanceCard.tsx
@@ -1,0 +1,172 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+const ENERGY_BALANCE_URL = 'https://n8n.ynovamarketplace.com/webhook/mockBalancoEnergetico';
+
+type EnergyBalanceResponse = {
+  cliente: string;
+  bandeira?: string | null;
+  consumoKWh?: number;
+  consumo?: number;
+  geracaoKWh?: number;
+  geracao?: number;
+  economiaMigracao?: {
+    saldoEnergeticoKWh?: number;
+    saldoEnergetico?: number;
+  };
+  impostos?: {
+    aliquotaExtra?: number | string;
+  };
+};
+
+type FetchState =
+  | { status: 'idle' | 'loading' }
+  | { status: 'success'; data: EnergyBalanceResponse }
+  | { status: 'error'; error: string };
+
+function formatNumber(value: number | undefined | null): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return '-';
+  }
+
+  return value.toLocaleString('pt-BR', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: value % 1 === 0 ? 0 : 2,
+  });
+}
+
+function formatPercent(value: unknown): string {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return `${value}%`;
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.includes('%') ? value : `${value}%`;
+  }
+
+  return '-';
+}
+
+export default function EnergyBalanceCard() {
+  const [state, setState] = useState<FetchState>({ status: 'idle' });
+
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    async function load() {
+      setState({ status: 'loading' });
+
+      try {
+        const response = await fetch(ENERGY_BALANCE_URL, {
+          method: 'POST',
+          body: '',
+          signal: abortController.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`Falha ao carregar dados (${response.status})`);
+        }
+
+        const data: EnergyBalanceResponse = await response.json();
+
+        setState({ status: 'success', data });
+      } catch (error) {
+        if (abortController.signal.aborted) {
+          return;
+        }
+
+        const message =
+          error instanceof Error ? error.message : 'Não foi possível carregar os dados.';
+
+        setState({ status: 'error', error: message });
+      }
+    }
+
+    load();
+
+    return () => {
+      abortController.abort();
+    };
+  }, []);
+
+  const content = useMemo(() => {
+    if (state.status === 'loading' || state.status === 'idle') {
+      return (
+        <div className="flex min-h-[160px] items-center justify-center text-sm text-gray-500 dark:text-gray-300">
+          Carregando…
+        </div>
+      );
+    }
+
+    if (state.status === 'error') {
+      return (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {state.error}
+        </div>
+      );
+    }
+
+    const { data } = state;
+    const consumo = data.consumoKWh ?? data.consumo;
+    const geracao = data.geracaoKWh ?? data.geracao;
+    const saldo = data.economiaMigracao?.saldoEnergeticoKWh ?? data.economiaMigracao?.saldoEnergetico;
+    const imposto = data.impostos?.aliquotaExtra;
+
+    return (
+      <div className="space-y-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+              {data.cliente ?? 'Cliente desconhecido'}
+            </h2>
+            {data.bandeira && (
+              <span className="mt-1 inline-flex rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-700">
+                Bandeira: {data.bandeira}
+              </span>
+            )}
+          </div>
+          <div className="rounded-lg bg-green-50 px-4 py-3 text-right">
+            <span className="block text-xs font-medium uppercase tracking-wide text-green-700">
+              Saldo Energético
+            </span>
+            <span className="text-2xl font-semibold text-green-700">
+              {formatNumber(saldo)} kWh
+            </span>
+          </div>
+        </div>
+
+        <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-[#2b3238] dark:bg-[#1a1f24]">
+            <dt className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Imposto Extra
+            </dt>
+            <dd className="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {formatPercent(imposto)}
+            </dd>
+          </div>
+          <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-[#2b3238] dark:bg-[#1a1f24]">
+            <dt className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Consumo
+            </dt>
+            <dd className="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {formatNumber(consumo)} kWh
+            </dd>
+          </div>
+          <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-[#2b3238] dark:bg-[#1a1f24]">
+            <dt className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Geração
+            </dt>
+            <dd className="mt-2 text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {formatNumber(geracao)} kWh
+            </dd>
+          </div>
+        </dl>
+      </div>
+    );
+  }, [state]);
+
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-[#2b3238] dark:bg-[#1a1f24]">
+      {content}
+    </section>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -20,7 +20,7 @@ import { mockUser } from '../data/mockData';
 const navigation = [
   { to: '/dashboard', label: 'Dashboard', icon: Home },
   { to: '/contratos', label: 'Contratos', icon: PieChart },
-  { to: '/leads', label: 'Balanço Energético', icon: FileText },
+  { to: '/leads/simulation', label: 'Balanço Energético', icon: FileText },
   /* { to: '/negociacoes', label: 'Negociações', icon: Handshake }, */
   /* { to: '/agenda', label: 'Agenda', icon: Calendar }, */
   { to: '/profile', label: 'Perfil', icon: User },

--- a/src/pages/LeadsSection.tsx
+++ b/src/pages/LeadsSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
 
 export default function LeadsSection() {
-  const tabs = [{ to: '/leads', label: 'Balanço Energético', end: true }];
+  const tabs = [{ to: '/leads/simulation', label: 'Balanço Energético', end: true }];
   return (
     <div className="space-y-6">
       <div>

--- a/src/pages/SimulationClientPage.tsx
+++ b/src/pages/SimulationClientPage.tsx
@@ -19,7 +19,7 @@ export default function SimulationClientPage() {
     return (
       <div className="space-y-4">
         <Link
-          to="/leads"
+          to="/leads/simulation"
           className={backLinkClass}
         >
           ← Voltar
@@ -35,7 +35,7 @@ export default function SimulationClientPage() {
     return (
       <div className="space-y-4">
         <Link
-          to="/leads"
+          to="/leads/simulation"
           className={backLinkClass}
         >
           ← Voltar
@@ -129,7 +129,7 @@ export default function SimulationClientPage() {
       <div className="flex items-start justify-between">
         <div>
           <Link
-            to="/leads"
+            to="/leads/simulation"
             className={backLinkClass}
           >
             ← Voltar

--- a/src/pages/SimulationClientsPage.tsx
+++ b/src/pages/SimulationClientsPage.tsx
@@ -4,6 +4,7 @@ import EmptyState from '../components/EmptyState';
 import { useSimulationClientes } from '../hooks/useSimulationClientes';
 import UploadXLSX from '../components/UploadXLSX';
 import { Search } from 'lucide-react';
+import EnergyBalanceCard from '../components/EnergyBalanceCard';
 
 export default function SimulationClientsPage() {
   const { clientes, loading, error, isUsingFallback } = useSimulationClientes();
@@ -35,6 +36,8 @@ export default function SimulationClientsPage() {
           <UploadXLSX />
         </div>
       </div>
+
+      <EnergyBalanceCard />
 
       <div className="relative">
         <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
@@ -73,7 +76,7 @@ export default function SimulationClientsPage() {
             {filteredClientes.map((cliente) => (
               <ListRow
                 key={cliente.id}
-                to={`/leads/${cliente.id}`}
+                to={`/leads/simulation/${cliente.id}`}
                 title={cliente.nome}
                 badgeLabel={`Bandeira: ${cliente.bandeira}`}
                 detail={`Imposto: ${cliente.imposto} • Consumo: ${cliente.consumo} kWh • Geração: ${cliente.geracao} kWh`}


### PR DESCRIPTION
## Summary
- add an energy balance card component that fetches client data from the backend webhook and renders the energy metrics
- place the card on the leads simulation page while keeping the existing client list and highlight the balance value in green
- update navigation and routes to use /leads/simulation so the new card is accessible from the sidebar and detail pages

## Testing
- npm test *(fails: ReferenceError: expect is not defined in vitest setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e41c07f5d08327bfb058c563c9b7fa