### PR TITLE
Implement contracts API integration

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
-﻿VITE_API_BASE_URL=http://localhost:3000
-VITE_API_MOCK=true
+VITE_API_BASE_URL=http://localhost:3000
+VITE_API_BASE=https://b3767060a437.ngrok-free.app
+VITE_API_MOCK=false
 VITE_PORTAL_MODE=gestao

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "start:server": "node server/index.js"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.51.11",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,151 @@
+import { createServer } from 'http';
+import { randomUUID } from 'crypto';
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
+const HOST = process.env.HOST || '0.0.0.0';
+
+const allowedOriginPatterns = [/^https?:\/\/localhost:\d+$/, /\.ynovamarketplace\.com$/];
+
+const contracts = [
+  {
+    id: '1',
+    contract_code: 'CTR-2024-061-0001',
+    client_id: '17f83280-750a-473c-99d2-2bfacd101813',
+    client_name: 'Cliente XPTO',
+    cnpj: '00.000.000/0001-00',
+    segment: 'Comercial',
+    contact_responsible: 'Maria Silva',
+    contracted_volume_mwh: '1500.75',
+    status: 'Ativo',
+    energy_source: 'Convencional',
+    contracted_modality: 'PLD',
+    start_date: '2024-01-01T00:00:00.000Z',
+    end_date: '2026-12-31T00:00:00.000Z',
+    billing_cycle: 'Mensal',
+    upper_limit_percent: '0.15',
+    lower_limit_percent: '0.05',
+    flexibility_percent: '0.1',
+    average_price_mwh: '320.5',
+    spot_price_ref_mwh: '299.9',
+    compliance_consumption: 'Em análise',
+    compliance_nf: 'Em análise',
+    compliance_invoice: 'Em análise',
+    compliance_charges: 'Em análise',
+    compliance_overall: 'Em análise',
+    created_at: '2024-03-01T12:00:00.000Z',
+    updated_at: '2024-03-01T12:00:00.000Z',
+  },
+];
+
+function isAllowedOrigin(origin) {
+  if (!origin) return false;
+  return allowedOriginPatterns.some((pattern) => pattern.test(origin));
+}
+
+function setCorsHeaders(res, origin) {
+  if (isAllowedOrigin(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+  }
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Access-Control-Max-Age', '86400');
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      if (!chunks.length) {
+        resolve({});
+        return;
+      }
+      try {
+        const text = Buffer.concat(chunks).toString('utf8');
+        resolve(JSON.parse(text));
+      } catch (error) {
+        reject(new Error('Invalid JSON body'));
+      }
+    });
+    req.on('error', (err) => reject(err));
+  });
+}
+
+function sendJson(res, statusCode, payload, origin) {
+  setCorsHeaders(res, origin);
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+const requiredFields = [
+  'contract_code',
+  'client_id',
+  'client_name',
+  'cnpj',
+  'segment',
+  'contact_responsible',
+  'contracted_volume_mwh',
+  'status',
+  'energy_source',
+  'contracted_modality',
+  'start_date',
+  'end_date',
+  'billing_cycle',
+];
+
+const server = createServer(async (req, res) => {
+  const origin = req.headers.origin || '';
+  const url = new URL(req.url || '/', 'http://localhost');
+
+  if (req.method === 'OPTIONS') {
+    setCorsHeaders(res, origin);
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  if (url.pathname === '/contracts' && req.method === 'GET') {
+    sendJson(res, 200, contracts, origin);
+    return;
+  }
+
+  if (url.pathname === '/contracts' && req.method === 'POST') {
+    try {
+      const payload = await parseBody(req);
+      const missing = requiredFields.filter((field) => !payload?.[field]);
+      if (missing.length > 0) {
+        sendJson(res, 400, { error: `Missing: ${missing.join(', ')}` }, origin);
+        return;
+      }
+
+      const now = new Date().toISOString();
+      const contract = {
+        id: randomUUID(),
+        ...payload,
+        created_at: now,
+        updated_at: now,
+      };
+      contracts.unshift(contract);
+      sendJson(res, 201, contract, origin);
+    } catch (error) {
+      sendJson(res, 400, { error: error instanceof Error ? error.message : 'Invalid request' }, origin);
+    }
+    return;
+  }
+
+  sendJson(res, 404, { error: 'Not Found' }, origin);
+});
+
+server.on('clientError', (err, socket) => {
+  if (socket.writable) {
+    socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`Contracts API listening on http://${HOST}:${PORT}`);
+});

--- a/src/pages/ContractsPage.tsx
+++ b/src/pages/ContractsPage.tsx
@@ -1,6 +1,47 @@
-import React, { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { ContractsAPI, Contract } from '../services/api';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Contract, createContract, getContracts } from '../services/contracts';
+
+type FormState = {
+  contract_code: string;
+  client_id: string;
+  client_name: string;
+  cnpj: string;
+  segment: string;
+  contact_responsible: string;
+  contracted_volume_mwh: string;
+  status: string;
+  energy_source: string;
+  contracted_modality: string;
+  start_date: string;
+  end_date: string;
+  billing_cycle: string;
+};
+
+const initialFormState: FormState = {
+  contract_code: '',
+  client_id: '',
+  client_name: '',
+  cnpj: '',
+  segment: '',
+  contact_responsible: '',
+  contracted_volume_mwh: '',
+  status: '',
+  energy_source: '',
+  contracted_modality: '',
+  start_date: '',
+  end_date: '',
+  billing_cycle: '',
+};
+
+function ensureIsoDate(value: string) {
+  if (!value) return value;
+  if (value.includes('T')) {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+  }
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+}
 
 function toCsv(rows: Contract[]) {
   const headers = [
@@ -37,6 +78,12 @@ function toCsv(rows: Contract[]) {
 }
 
 export default function ContractsPage() {
+  const [contracts, setContracts] = useState<Contract[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [form, setForm] = useState<FormState>(initialFormState);
+
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [search, setSearch] = useState('');
@@ -45,15 +92,74 @@ export default function ContractsPage() {
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
 
-  const { data, isFetching } = useQuery({
-    queryKey: ['contracts', { page, pageSize, search, cnpj, status, startDate, endDate }],
-    queryFn: () => ContractsAPI.list({ page, pageSize, search, cnpj, status, startDate, endDate }),
-    keepPreviousData: true,
-  });
+  useEffect(() => {
+    let isMounted = true;
+    setLoading(true);
+    setError(null);
+    getContracts()
+      .then((data) => {
+        if (!isMounted) return;
+        setContracts(data);
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setError('Não foi possível carregar os contratos da API.');
+      })
+      .finally(() => {
+        if (!isMounted) return;
+        setLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const filteredContracts = useMemo(() => {
+    const searchTerm = search.trim().toLowerCase();
+    const cnpjFilter = cnpj.replace(/[^0-9]/g, '');
+    const statusFilter = status.trim().toLowerCase();
+    const startDateFilter = startDate ? new Date(`${startDate}-01T00:00:00Z`) : null;
+    const endDateFilter = endDate ? new Date(`${endDate}-01T00:00:00Z`) : null;
+
+    return contracts.filter((contract) => {
+      const normalizedCnpj = contract.cnpj.replace(/[^0-9]/g, '');
+      const contractStart = new Date(contract.start_date);
+      const contractEnd = new Date(contract.end_date);
+
+      const matchesSearch = !searchTerm
+        || contract.contract_code.toLowerCase().includes(searchTerm)
+        || contract.client_name.toLowerCase().includes(searchTerm);
+
+      const matchesCnpj = !cnpjFilter || normalizedCnpj.includes(cnpjFilter);
+      const matchesStatus = !statusFilter || contract.status.toLowerCase() === statusFilter;
+
+      const matchesStartDate = !startDateFilter
+        || (!Number.isNaN(contractEnd.getTime()) && contractEnd >= startDateFilter);
+      const matchesEndDate = !endDateFilter
+        || (!Number.isNaN(contractStart.getTime()) && contractStart <= endDateFilter);
+
+      return matchesSearch && matchesCnpj && matchesStatus && matchesStartDate && matchesEndDate;
+    });
+  }, [contracts, search, cnpj, status, startDate, endDate]);
+
+  const totalPages = useMemo(
+    () => Math.max(1, Math.ceil(filteredContracts.length / pageSize)),
+    [filteredContracts.length, pageSize],
+  );
+
+  useEffect(() => {
+    setPage((prev) => Math.min(prev, totalPages));
+  }, [totalPages]);
+
+  const currentPageItems = useMemo(() => {
+    const startIndex = (page - 1) * pageSize;
+    return filteredContracts.slice(startIndex, startIndex + pageSize);
+  }, [filteredContracts, page, pageSize]);
 
   const formatNumber = (value: string | number | null) => {
     if (value === null || value === undefined || value === '') return '-';
-    const numeric = typeof value === 'number' ? value : Number(value);
+    const numeric = typeof value === 'number' ? value : Number(String(value).replace(',', '.'));
     if (Number.isNaN(numeric)) return String(value);
     return numeric.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
   };
@@ -66,7 +172,7 @@ export default function ContractsPage() {
   };
 
   const onExport = () => {
-    const csv = toCsv(data?.items || []);
+    const csv = toCsv(filteredContracts);
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -76,11 +182,185 @@ export default function ContractsPage() {
     URL.revokeObjectURL(url);
   };
 
-  const totalPages = useMemo(() => (data ? Math.max(1, Math.ceil(data.total / data.pageSize)) : 1), [data]);
+  const handleFormChange = (field: keyof FormState) => (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { value } = event.target;
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      const payload = {
+        ...form,
+        start_date: ensureIsoDate(form.start_date),
+        end_date: ensureIsoDate(form.end_date),
+      };
+      const saved = await createContract(payload);
+      setContracts((prev) => [saved, ...prev]);
+      setForm(initialFormState);
+    } catch (err) {
+      console.error(err);
+      setError('Falha ao salvar contrato.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-semibold">Contratos Ativos</h1>
+
+      <form onSubmit={handleSubmit} className="border rounded p-4 space-y-4">
+        <h2 className="text-lg font-medium">Novo contrato</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Código do contrato</span>
+            <input
+              required
+              value={form.contract_code}
+              onChange={handleFormChange('contract_code')}
+              className="border rounded px-2 py-1"
+              placeholder="CTR-2024-..."
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Cliente (ID)</span>
+            <input
+              required
+              value={form.client_id}
+              onChange={handleFormChange('client_id')}
+              className="border rounded px-2 py-1"
+              placeholder="UUID"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Nome do cliente</span>
+            <input
+              required
+              value={form.client_name}
+              onChange={handleFormChange('client_name')}
+              className="border rounded px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>CNPJ</span>
+            <input
+              required
+              value={form.cnpj}
+              onChange={handleFormChange('cnpj')}
+              className="border rounded px-2 py-1"
+              placeholder="00.000.000/0000-00"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Segmento</span>
+            <input
+              required
+              value={form.segment}
+              onChange={handleFormChange('segment')}
+              className="border rounded px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Responsável</span>
+            <input
+              required
+              value={form.contact_responsible}
+              onChange={handleFormChange('contact_responsible')}
+              className="border rounded px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Volume contratado (MWh)</span>
+            <input
+              required
+              type="number"
+              step="0.01"
+              value={form.contracted_volume_mwh}
+              onChange={handleFormChange('contracted_volume_mwh')}
+              className="border rounded px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Status</span>
+            <select
+              required
+              value={form.status}
+              onChange={handleFormChange('status')}
+              className="border rounded px-2 py-1"
+            >
+              <option value="">Selecione</option>
+              <option value="Ativo">Ativo</option>
+              <option value="Em análise">Em análise</option>
+              <option value="Inativo">Inativo</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Fonte</span>
+            <input
+              required
+              value={form.energy_source}
+              onChange={handleFormChange('energy_source')}
+              className="border rounded px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Modalidade</span>
+            <input
+              required
+              value={form.contracted_modality}
+              onChange={handleFormChange('contracted_modality')}
+              className="border rounded px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Início</span>
+            <input
+              required
+              type="date"
+              value={form.start_date}
+              onChange={handleFormChange('start_date')}
+              className="border rounded px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Fim</span>
+            <input
+              required
+              type="date"
+              value={form.end_date}
+              onChange={handleFormChange('end_date')}
+              className="border rounded px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm md:col-span-3">
+            <span>Ciclo de faturamento</span>
+            <input
+              required
+              value={form.billing_cycle}
+              onChange={handleFormChange('billing_cycle')}
+              className="border rounded px-2 py-1"
+            />
+          </label>
+        </div>
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            className="px-4 py-2 bg-yn-orange text-white rounded disabled:opacity-50"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Salvando...' : 'Salvar contrato'}
+          </button>
+        </div>
+      </form>
+
+      {error && (
+        <div className="px-4 py-2 rounded bg-red-100 text-red-700 text-sm">
+          {error}
+        </div>
+      )}
 
       <div className="grid grid-cols-1 md:grid-cols-6 gap-2">
         <input
@@ -138,8 +418,8 @@ export default function ContractsPage() {
             </tr>
           </thead>
           <tbody>
-            {data?.items?.map((contract) => {
-              const statusVariant = contract.status.toLowerCase();
+            {currentPageItems.map((contract) => {
+              const statusVariant = (contract.status || '').toLowerCase();
               const badgeClass = statusVariant === 'ativo'
                 ? 'bg-green-100 text-green-700'
                 : statusVariant === 'em análise'
@@ -167,8 +447,11 @@ export default function ContractsPage() {
                 </tr>
               );
             })}
-            {isFetching && (
+            {loading && (
               <tr><td colSpan={12} className="p-4 text-center text-gray-500">Carregando...</td></tr>
+            )}
+            {!loading && currentPageItems.length === 0 && (
+              <tr><td colSpan={12} className="p-4 text-center text-gray-500">Nenhum contrato encontrado.</td></tr>
             )}
           </tbody>
         </table>

--- a/src/services/contracts.ts
+++ b/src/services/contracts.ts
@@ -1,0 +1,61 @@
+export type Contract = {
+  id: string;
+  contract_code: string;
+  client_id: string;
+  client_name: string;
+  cnpj: string;
+  segment: string;
+  contact_responsible: string;
+  contracted_volume_mwh: string;
+  status: string;
+  energy_source: string;
+  contracted_modality: string;
+  start_date: string;
+  end_date: string;
+  billing_cycle: string;
+  upper_limit_percent?: string | null;
+  lower_limit_percent?: string | null;
+  flexibility_percent?: string | null;
+  average_price_mwh?: string | null;
+  spot_price_ref_mwh?: string | null;
+  compliance_consumption?: string | null;
+  compliance_nf?: string | null;
+  compliance_invoice?: string | null;
+  compliance_charges?: string | null;
+  compliance_overall?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+const API_BASE = import.meta.env.VITE_API_BASE?.replace(/\/$/, '') || '';
+
+function buildUrl(path: string) {
+  return `${API_BASE}${path}`;
+}
+
+export async function getContracts(): Promise<Contract[]> {
+  const response = await fetch(buildUrl('/contracts'), { method: 'GET' });
+  if (!response.ok) {
+    throw new Error(`GET /contracts ${response.status}`);
+  }
+  return response.json();
+}
+
+export type CreateContractPayload = Omit<Contract, 'id' | 'created_at' | 'updated_at'>;
+
+export async function createContract(payload: CreateContractPayload): Promise<Contract> {
+  const response = await fetch(buildUrl('/contracts'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `POST /contracts ${response.status}`);
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add a lightweight Node server that exposes GET/POST /contracts with the required CORS behaviour and English field names
- wire ContractsPage.tsx to the external contracts endpoint with a creation form and local filtering utilities
- configure environment defaults and scripts for the contracts API base URL

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6a63e8b8883278c33eaa7ee294536