### PR TITLE
Persist contract create and edit actions via backend API

### DIFF
--- a/src/pages/contratos/index.tsx
+++ b/src/pages/contratos/index.tsx
@@ -152,16 +152,17 @@ export default function ContratosPage() {
   }, [contratosFiltrados]);
 
   const handleCreateContract = React.useCallback(
-    (contract: ContractMock) => {
-      addContract(contract);
+    async (contract: ContractMock) => {
+      const saved = await addContract(contract);
       setIsCreateOpen(false);
-      if (contract.cicloFaturamento) {
-        setPeriodoSelecionado(contract.cicloFaturamento);
+      if (saved.cicloFaturamento) {
+        setPeriodoSelecionado(saved.cicloFaturamento);
       }
       setSort('recentes');
       setSearchTerm('');
-      setContratoSelecionado(contract.id);
+      setContratoSelecionado(saved.id);
       setPaginaAtual(1);
+      return saved;
     },
     [addContract]
   );


### PR DESCRIPTION
## Summary
- convert the contracts context to use the backend API for create/update/delete flows, including payload normalization and endpoint resolution
- update the manual creation modal to await API persistence with submission states and surface errors
- refresh the contract edit page to await backend saves and report failures to the user

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6c8005b80832788eacca3ddc0549d