### PR TITLE
Fix contract creation payload to satisfy backend validation

### DIFF
--- a/src/pages/ContractsPage.tsx
+++ b/src/pages/ContractsPage.tsx
@@ -3,8 +3,6 @@ import { useContracts } from '../hooks/useContracts';
 import { Contract, createContract } from '../services/contracts';
 
 type FormState = {
-  contract_code: string;
-  client_id: string;
   client_name: string;
   cnpj: string;
   segment: string;
@@ -16,11 +14,10 @@ type FormState = {
   start_date: string;
   end_date: string;
   billing_cycle: string;
+  groupName: string;
 };
 
 const initialFormState: FormState = {
-  contract_code: '',
-  client_id: '',
   client_name: '',
   cnpj: '',
   segment: '',
@@ -32,6 +29,7 @@ const initialFormState: FormState = {
   start_date: '',
   end_date: '',
   billing_cycle: '',
+  groupName: '',
 };
 
 function ensureIsoDate(value: string) {
@@ -174,10 +172,13 @@ export default function ContractsPage() {
     setFormError(null);
     setIsSubmitting(true);
     try {
+      const { groupName, ...rest } = form;
+      const sanitizedGroupName = groupName.trim() || 'default';
       const payload = {
-        ...form,
+        ...rest,
         start_date: ensureIsoDate(form.start_date),
         end_date: ensureIsoDate(form.end_date),
+        groupName: sanitizedGroupName,
       };
       const saved = await createContract(payload);
       setContracts((prev) => [saved, ...prev]);
@@ -198,32 +199,21 @@ export default function ContractsPage() {
         <h2 className="text-lg font-medium">Novo contrato</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
           <label className="flex flex-col gap-1 text-sm">
-            <span>Código do contrato</span>
-            <input
-              required
-              value={form.contract_code}
-              onChange={handleFormChange('contract_code')}
-              className="border rounded px-2 py-1"
-              placeholder="CTR-2024-..."
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-sm">
-            <span>Cliente (ID)</span>
-            <input
-              required
-              value={form.client_id}
-              onChange={handleFormChange('client_id')}
-              className="border rounded px-2 py-1"
-              placeholder="UUID"
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-sm">
             <span>Nome do cliente</span>
             <input
               required
               value={form.client_name}
               onChange={handleFormChange('client_name')}
               className="border rounded px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Grupo</span>
+            <input
+              value={form.groupName}
+              onChange={handleFormChange('groupName')}
+              className="border rounded px-2 py-1"
+              placeholder="default"
             />
           </label>
           <label className="flex flex-col gap-1 text-sm">

--- a/src/pages/contratos/ContractsContext.tsx
+++ b/src/pages/contratos/ContractsContext.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ContractMock } from '../../mocks/contracts';
 import { mockContracts } from '../../mocks/contracts';
+import { isValidUuid } from '../../utils/uuid';
 
 const DEFAULT_API_URL = 'https://b3767060a437.ngrok-free.app/contracts';
 
@@ -723,16 +724,17 @@ const contractToApiPayload = (contract: ContractMock): Record<string, unknown> =
   };
 
   const supplier = findDadosValue(['fornecedor', 'supplier']);
-  const groupName = findDadosValue(['grupo', 'group']);
+  const rawGroupName = findDadosValue(['grupo', 'group']);
   const volumeField =
     contract.dadosContrato.find((item) => /volume/i.test(item.label))?.value ?? contract.flex;
   const contractedVolume = parseNumericInput(volumeField);
+  const normalizedGroupName = normalizeString(rawGroupName);
+  const resolvedGroupName = normalizedGroupName || 'default';
+  const rawClientId = normalizeString(contract.id);
 
   const payload: Record<string, unknown> = {
-    contract_code: normalizeString(contract.codigo) || contract.id,
-    client_id: normalizeString(contract.id),
     client_name: normalizeString(contract.cliente),
-    groupName: groupName || undefined,
+    groupName: resolvedGroupName,
     supplier: supplier || undefined,
     cnpj: normalizeString(contract.cnpj),
     segment: normalizeString(contract.segmento),
@@ -758,6 +760,10 @@ const contractToApiPayload = (contract: ContractMock): Record<string, unknown> =
     adjusted: parsePercentInput(contract.flex) ? true : undefined,
     price: parseNumericInput(contract.precoMedio) ?? contract.precoMedio,
   };
+
+  if (rawClientId && isValidUuid(rawClientId)) {
+    payload.client_id = rawClientId;
+  }
 
   return Object.fromEntries(
     Object.entries(payload).filter(([, value]) => value !== undefined && value !== null && value !== '')

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -99,6 +99,7 @@ export type Contract = {
   start_date: string;
   end_date: string;
   billing_cycle: string;
+  groupName?: string;
   upper_limit_percent: string | number | null;
   lower_limit_percent: string | number | null;
   flexibility_percent: string | number | null;

--- a/src/services/contracts.ts
+++ b/src/services/contracts.ts
@@ -1,3 +1,5 @@
+import { isValidUuid } from '../utils/uuid';
+
 export type Contract = {
   id: string;
   contract_code: string;
@@ -13,6 +15,7 @@ export type Contract = {
   start_date: string;
   end_date: string;
   billing_cycle: string;
+  groupName?: string;
   upper_limit_percent?: string | number | null;
   lower_limit_percent?: string | number | null;
   flexibility_percent?: string | number | null;
@@ -59,6 +62,7 @@ function normalizeContract(raw: any, index: number): Contract {
     start_date: toString(raw?.start_date),
     end_date: toString(raw?.end_date),
     billing_cycle: toString(raw?.billing_cycle),
+    groupName: raw?.groupName ? toString(raw?.groupName) : undefined,
     upper_limit_percent: raw?.upper_limit_percent ?? null,
     lower_limit_percent: raw?.lower_limit_percent ?? null,
     flexibility_percent: raw?.flexibility_percent ?? null,
@@ -186,15 +190,40 @@ export async function getContracts(signal?: AbortSignal): Promise<Contract[]> {
   return fetchContracts(signal);
 }
 
-export type CreateContractPayload = Omit<Contract, 'id' | 'created_at' | 'updated_at'>;
+type BaseContractPayload = Omit<
+  Contract,
+  'id' | 'contract_code' | 'client_id' | 'created_at' | 'updated_at' | 'groupName'
+>;
+
+export type CreateContractPayload = BaseContractPayload & {
+  groupName: string;
+  client_id?: string;
+};
 
 export async function createContract(payload: CreateContractPayload): Promise<Contract> {
+  const sanitizedPayload: Record<string, unknown> = {
+    ...payload,
+    groupName: payload.groupName.trim() || 'default',
+  };
+
+  delete sanitizedPayload.contract_code;
+  delete sanitizedPayload.id;
+  delete sanitizedPayload.created_at;
+  delete sanitizedPayload.updated_at;
+
+  const trimmedClientId = payload.client_id?.trim();
+  if (trimmedClientId && isValidUuid(trimmedClientId)) {
+    sanitizedPayload.client_id = trimmedClientId;
+  } else {
+    delete sanitizedPayload.client_id;
+  }
+
   const response = await fetch(`${CONTRACTS_API}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(payload),
+    body: JSON.stringify(sanitizedPayload),
   });
 
   if (!response.ok) {

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,11 @@
+const UUID_REGEX =
+  /^([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$/i;
+
+export const isValidUuid = (value: string | null | undefined): boolean => {
+  if (!value) {
+    return false;
+  }
+  return UUID_REGEX.test(value);
+};
+
+export { UUID_REGEX };


### PR DESCRIPTION
## Summary
- stop collecting contract_code and client_id in the contracts form and ensure a default group name is sent
- sanitize contract creation requests so groupName is always present and client_id is only forwarded when it is a valid UUID
- share a UUID validation helper and update contract typings with the optional groupName field

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7c8a973b083278de655f230f99b50