### PR TITLE
Remove client ID input and default group name

### DIFF
--- a/openapi/contracts.yaml
+++ b/openapi/contracts.yaml
@@ -36,6 +36,57 @@ paths:
               schema:
                 type: array
                 items: { $ref: '#/components/schemas/Contract' }
+    post:
+      summary: Create a new contract
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateContractInput'
+            example:
+              contract_code: CTR-2024-061-0002
+              client_name: Empresa Exemplo SA
+              groupName: default
+              cnpj: 11.222.333/0001-44
+              segment: Industrial
+              contact_responsible: Ana Pereira
+              contracted_volume_mwh: '1800.5'
+              status: Ativo
+              energy_source: Renovável
+              contracted_modality: Tarifa Fixa
+              start_date: 2024-04-01T00:00:00Z
+              end_date: 2025-03-31T23:59:59Z
+              billing_cycle: Mensal
+      responses:
+        '201':
+          description: Contract created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Contract' }
+        '400':
+          description: Invalid payload
+      x-codeSamples:
+        - lang: cURL
+          label: Create contract
+          source: |
+            curl -X POST "https://api.example.com/contracts" \
+              -H "Content-Type: application/json" \
+              -d '{
+                "contract_code": "CTR-2024-061-0002",
+                "client_name": "Empresa Exemplo SA",
+                "groupName": "default",
+                "cnpj": "11.222.333/0001-44",
+                "segment": "Industrial",
+                "contact_responsible": "Ana Pereira",
+                "contracted_volume_mwh": "1800.5",
+                "status": "Ativo",
+                "energy_source": "Renovável",
+                "contracted_modality": "Tarifa Fixa",
+                "start_date": "2024-04-01T00:00:00Z",
+                "end_date": "2025-03-31T23:59:59Z",
+                "billing_cycle": "Mensal"
+              }'
 components:
   schemas:
     Contract:
@@ -43,8 +94,9 @@ components:
       properties:
         id: { type: string }
         contract_code: { type: string }
-        client_id: { type: string }
         client_name: { type: string }
+        client_id: { type: string }
+        groupName: { type: string }
         cnpj: { type: string }
         segment: { type: string }
         contact_responsible: { type: string }
@@ -67,3 +119,45 @@ components:
         compliance_overall: { type: string }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
+    CreateContractInput:
+      type: object
+      required:
+        - contract_code
+        - client_name
+        - cnpj
+        - segment
+        - contact_responsible
+        - contracted_volume_mwh
+        - status
+        - energy_source
+        - contracted_modality
+        - start_date
+        - end_date
+        - billing_cycle
+      properties:
+        contract_code: { type: string }
+        client_name: { type: string }
+        groupName:
+          type: string
+          description: Nome do agrupador do contrato
+          default: default
+        cnpj: { type: string }
+        segment: { type: string }
+        contact_responsible: { type: string }
+        contracted_volume_mwh: { type: string }
+        status: { type: string, enum: [Ativo, "Em análise", Inativo] }
+        energy_source: { type: string }
+        contracted_modality: { type: string }
+        start_date: { type: string, format: date-time }
+        end_date: { type: string, format: date-time }
+        billing_cycle: { type: string }
+        upper_limit_percent: { type: string, nullable: true }
+        lower_limit_percent: { type: string, nullable: true }
+        flexibility_percent: { type: string, nullable: true }
+        average_price_mwh: { type: string, nullable: true }
+        spot_price_ref_mwh: { type: string, nullable: true }
+        compliance_consumption: { type: string, nullable: true }
+        compliance_nf: { type: string, nullable: true }
+        compliance_invoice: { type: string, nullable: true }
+        compliance_charges: { type: string, nullable: true }
+        compliance_overall: { type: string, nullable: true }

--- a/server/index.js
+++ b/server/index.js
@@ -10,8 +10,9 @@ const contracts = [
   {
     id: '1',
     contract_code: 'CTR-2024-061-0001',
-    client_id: '17f83280-750a-473c-99d2-2bfacd101813',
     client_name: 'Cliente XPTO',
+    client_id: '17f83280-750a-473c-99d2-2bfacd101813',
+    groupName: 'default',
     cnpj: '00.000.000/0001-00',
     segment: 'Comercial',
     contact_responsible: 'Maria Silva',
@@ -83,7 +84,6 @@ function sendJson(res, statusCode, payload, origin) {
 
 const requiredFields = [
   'contract_code',
-  'client_id',
   'client_name',
   'cnpj',
   'segment',
@@ -126,6 +126,10 @@ const server = createServer(async (req, res) => {
       const contract = {
         id: randomUUID(),
         ...payload,
+        client_id: randomUUID(),
+        groupName: typeof payload.groupName === 'string' && payload.groupName.trim()
+          ? payload.groupName
+          : 'default',
         created_at: now,
         updated_at: now,
       };

--- a/src/pages/ContractsPage.tsx
+++ b/src/pages/ContractsPage.tsx
@@ -4,7 +4,6 @@ import { Contract, createContract } from '../services/contracts';
 
 type FormState = {
   contract_code: string;
-  client_id: string;
   client_name: string;
   cnpj: string;
   segment: string;
@@ -20,7 +19,6 @@ type FormState = {
 
 const initialFormState: FormState = {
   contract_code: '',
-  client_id: '',
   client_name: '',
   cnpj: '',
   segment: '',
@@ -176,6 +174,7 @@ export default function ContractsPage() {
     try {
       const payload = {
         ...form,
+        groupName: 'default',
         start_date: ensureIsoDate(form.start_date),
         end_date: ensureIsoDate(form.end_date),
       };
@@ -205,16 +204,6 @@ export default function ContractsPage() {
               onChange={handleFormChange('contract_code')}
               className="border rounded px-2 py-1"
               placeholder="CTR-2024-..."
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-sm">
-            <span>Cliente (ID)</span>
-            <input
-              required
-              value={form.client_id}
-              onChange={handleFormChange('client_id')}
-              className="border rounded px-2 py-1"
-              placeholder="UUID"
             />
           </label>
           <label className="flex flex-col gap-1 text-sm">

--- a/src/pages/contratos/ContractsContext.tsx
+++ b/src/pages/contratos/ContractsContext.tsx
@@ -730,9 +730,8 @@ const contractToApiPayload = (contract: ContractMock): Record<string, unknown> =
 
   const payload: Record<string, unknown> = {
     contract_code: normalizeString(contract.codigo) || contract.id,
-    client_id: normalizeString(contract.id),
     client_name: normalizeString(contract.cliente),
-    groupName: groupName || undefined,
+    groupName: groupName || 'default',
     supplier: supplier || undefined,
     cnpj: normalizeString(contract.cnpj),
     segment: normalizeString(contract.segmento),

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -87,8 +87,9 @@ export type ContractsQuery = {
 export type Contract = {
   id: string;
   contract_code: string;
-  client_id: string;
   client_name: string;
+  client_id?: string;
+  groupName?: string;
   cnpj: string;
   segment: string;
   contact_responsible: string;

--- a/src/services/contracts.ts
+++ b/src/services/contracts.ts
@@ -1,8 +1,9 @@
 export type Contract = {
   id: string;
   contract_code: string;
-  client_id: string;
   client_name: string;
+  client_id?: string;
+  groupName?: string;
   cnpj: string;
   segment: string;
   contact_responsible: string;
@@ -47,8 +48,9 @@ function normalizeContract(raw: any, index: number): Contract {
   return {
     id: toString(idSource, String(index)),
     contract_code: toString(raw?.contract_code),
-    client_id: toString(raw?.client_id),
     client_name: toString(raw?.client_name),
+    client_id: raw?.client_id == null ? undefined : toString(raw?.client_id),
+    groupName: raw?.groupName == null ? undefined : toString(raw?.groupName),
     cnpj: toString(raw?.cnpj),
     segment: toString(raw?.segment),
     contact_responsible: toString(raw?.contact_responsible),
@@ -186,7 +188,7 @@ export async function getContracts(signal?: AbortSignal): Promise<Contract[]> {
   return fetchContracts(signal);
 }
 
-export type CreateContractPayload = Omit<Contract, 'id' | 'created_at' | 'updated_at'>;
+export type CreateContractPayload = Omit<Contract, 'id' | 'created_at' | 'updated_at' | 'client_id'>;
 
 export async function createContract(payload: CreateContractPayload): Promise<Contract> {
   const response = await fetch(`${CONTRACTS_API}`, {
@@ -194,7 +196,12 @@ export async function createContract(payload: CreateContractPayload): Promise<Co
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(payload),
+    body: JSON.stringify({
+      ...payload,
+      groupName: typeof payload.groupName === 'string' && payload.groupName.trim()
+        ? payload.groupName
+        : 'default',
+    }),
   });
 
   if (!response.ok) {

--- a/src/services/mockApi.ts
+++ b/src/services/mockApi.ts
@@ -18,6 +18,7 @@ const mockContracts: Contract[] = Array.from({ length: 20 }).map((_, i) => {
     contract_code: `CTR-2024-${String(i + 1).padStart(3, '0')}`,
     client_id: randomId,
     client_name: `Cliente ${i + 1}`,
+    groupName: 'default',
     cnpj: `00.000.000/000${i % 10}-0${i % 10}`,
     segment: i % 2 === 0 ? 'Comercial' : 'Industrial',
     contact_responsible: i % 2 === 0 ? 'Maria Silva' : 'João Souza',


### PR DESCRIPTION
## Summary
- remove the client ID field from the contracts form and ensure groupName defaults to "default"
- generate client IDs on the server while defaulting the group name across API and mock data
- update the OpenAPI contract with a POST definition and example curl call

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7e748dbdc8327a91c31cb09fe744e