### PR TITLE
Fix contracts API normalization and filtering

### DIFF
--- a/src/pages/contratos/index.tsx
+++ b/src/pages/contratos/index.tsx
@@ -89,7 +89,10 @@ export default function ContratosPage() {
     const numericSearch = normalizedSearch.replace(/\D/g, '');
 
     const filtrados = contracts.filter((contrato) => {
-      const matchesPeriodo = periodoSelecionado ? contrato.periodos.includes(periodoSelecionado) : true;
+      const matchesPeriodo =
+        !periodoSelecionado ||
+        contrato.periodos.length === 0 ||
+        contrato.periodos.includes(periodoSelecionado);
       if (!matchesPeriodo) return false;
 
       if (!normalizedSearch) return true;


### PR DESCRIPTION
## Summary
- normalize the contracts API response handling so both array and object payloads are accepted and unexpected payloads are logged
- forward ngrok skip header when fetching and keep contracts without period metadata visible when filtering by billing cycle

## Testing
- npm run test *(fails: ReferenceError: expect is not defined from test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e7f21c9a388327b9f15d83ba8d5d7f